### PR TITLE
classloader's getResource needs a prepending slash to work

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextInitializer.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/ContextInitializer.java
@@ -54,7 +54,7 @@ public class ContextInitializer {
   final private static String TAG_MANIFEST           = "manifest";
   final private static String TAG_LOGBACK            = "logback";
   final private static String MANIFEST_FILE          = "AndroidManifest.xml";
-  final private static String ASSETS_DIR             = "assets/";
+  final private static String ASSETS_DIR             = "/assets/";
   final private static String SDCARD_DIR             = "/sdcard/logback/";
   
   final LoggerContext loggerContext;


### PR DESCRIPTION
Hi there,

I tried to integrate Logback in my Android project and put the Logback configuration in the assets directory mentioned in the manual, which did not work. When I stepped into the code I saw that the config file in the assets directory is fetched via class loader's getResource. AFAIK this needs a prepended slash to get resources of the current classpath. So I added that, compiled the lib and put the snapshot dependency in my Maven configuration and ........ tada! It worked =)
