### PR TITLE
Fixed an issue where %xThrowable is included in tagEncoder

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/android/LogcatAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/android/LogcatAppender.java
@@ -18,13 +18,9 @@ import android.util.Log;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
-import ch.qos.logback.classic.pattern.NopThrowableInformationConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 import ch.qos.logback.core.Layout;
-import ch.qos.logback.core.pattern.Converter;
-import ch.qos.logback.core.pattern.ConverterUtil;
-import ch.qos.logback.core.pattern.PostCompileProcessor;
 
 /**
  * An appender that wraps the native Android logging mechanism (<i>logcat</i>);
@@ -67,29 +63,19 @@ public class LogcatAppender extends AppenderBase<ILoggingEvent> {
 			addError("No layout set for the appender named [" + name + "].");
 			return;
 		}
-		
+
 		// tag encoder is optional but needs a layout
 		if (this.tagEncoder != null) {
 			final Layout<?> layout = this.tagEncoder.getLayout();
-			
+
 			if (layout == null) {
 				addError("No tag layout set for the appender named [" + name + "].");
 				return;
 			}
-			
-			if (!(layout instanceof PatternLayout)) {
-				addWarn("The tag layout set for the appender named [" + name +
-						"] isn't a [" + PatternLayout.class.getName() +"].");
-			}
-			else {
+
+			if (layout instanceof PatternLayout) {
 				final PatternLayout tagLayout = (PatternLayout) layout;
-				tagLayout.setPostCompileProcessor(new PostCompileProcessor<ILoggingEvent>() {
-					public void process(Converter<ILoggingEvent> head) {
-						Converter<ILoggingEvent> tail = ConverterUtil.findTail(head);
-						Converter<ILoggingEvent> exConverter = new NopThrowableInformationConverter();
-						tail.setNext(exConverter);
-					}		
-				});
+				tagLayout.setPostCompileProcessor(null);
 			}
 		}
 


### PR DESCRIPTION
logback silently includes %xThrowable in the tagEncoder pattern at the
end to display the stack trace when logging a throwable. This probably
does not make sense for the log tag, which is meant to be short.

Created a new PatternLayout that makes sure the postCompileProcessor is
null and a PatternLayoutEncoder to be used in the LogcatAppender.
