### PR TITLE
Updated doc for ProGuard

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,12 @@ When optimizing your application with [ProGuard](http://developer.android.com/to
 -keepattributes *Annotation*
 ```
 
+If you don't use the mailing features of Logback, you might encounter error while exporting your app with ProGuard. You can add this last rule:
+
+```
+-dontwarn ch.qos.logback.core.net.*
+```
+
 
 Other Documentation
 -------------------


### PR DESCRIPTION
ProGuard returns an error when the mailing libraries are not included

```
Warning: ch.qos.logback.core.net.SMTPAppenderBase: can't find referenced class javax.mail.Transport
```

Adding a config to the proguard file prevents this.
