### PR TITLE
Adding a FileBufferingSocketAppender

### DIFF
--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -101,6 +101,29 @@
       <artifactId>subethasmtp</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>hamcrest-core</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/FileBufferingConfiguration.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/FileBufferingConfiguration.java
@@ -1,0 +1,213 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.core.spi.ContextAware;
+import com.google.common.base.Strings;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for {@link FileBufferingSocketAppender}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class FileBufferingConfiguration {
+
+  public static final String DEFAULT_FILE_EXT = ".ser";
+  public static final int DEFAULT_BATCH_SIZE = 50;
+  public static final long DEFAULT_READ_INTERVAL = TimeUnit.MINUTES.toMillis(1);
+  public static final int DEFAULT_FILE_COUNT_QUOTA = 500;
+
+  private String logFolder;
+  private String fileExtension = DEFAULT_FILE_EXT;
+  private int batchSize = DEFAULT_BATCH_SIZE;
+  private long readInterval = DEFAULT_READ_INTERVAL;
+  private int fileCountQuota = DEFAULT_FILE_COUNT_QUOTA;
+
+  /**
+   * The path to the folder to save the serialized log events in.
+   *
+   * @return log folder path
+   */
+  public String getLogFolder() {
+    return logFolder;
+  }
+
+  /**
+   * Sets the path to the folder to save the serialized log events in.
+   * This configuration value is required.
+   *
+   * @param logFolder log folder path
+   */
+  public void setLogFolder(final String logFolder) {
+    this.logFolder = format(logFolder);
+  }
+
+  /**
+   * The maximum number of events sent in each batch.
+   *
+   * @return the max event count
+   */
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  /**
+   * Sets the maximum number of events sent in each batch.
+   * The default value is 50.
+   *
+   * @param batchSize the max event count
+   */
+  public void setBatchSize(final int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  /**
+   * The interval in milliseconds in which events should be sent over the socket
+   * or deleted according to the configured quota.
+   *
+   * @return the read interval
+   */
+  public long getReadInterval() {
+    return readInterval;
+  }
+
+  /**
+   * Sets the interval in milliseconds in which events should be sent over the socket or
+   * deleted according to the configured quota. The default value is one minute.
+   *
+   * @param readInterval the read interval
+   */
+  public void setReadInterval(final long readInterval) {
+    this.readInterval = readInterval;
+  }
+
+  /**
+   * The file extension of the serialized log events.
+   *
+   * @return the file extension
+   */
+  public String getFileExtension() {
+    return fileExtension;
+  }
+
+  /**
+   * Sets the file extension of the serialized log events. The default value is ".ser".
+   *
+   * @param fileExtension the file extension
+   */
+  public void setFileExtension(final String fileExtension) {
+    this.fileExtension = fileExtension;
+  }
+
+  /**
+   * The file count quota, which defines how many files are allowed to be stored on disk.
+   *
+   * @return the file count quota
+   */
+  public int getFileCountQuota() {
+    return fileCountQuota;
+  }
+
+  /**
+   * Sets the file count quota, which defines how many files are allowed to be stored on disk.
+   * <b>Note:</b> This is not a hard limit, meaning the quota is only maintained in each specified interval.
+   * So, serialized log events might grow over this specified quota within the {@code readInterval}.
+   *
+   * @param fileCountQuota
+   */
+  public void setFileCountQuota(final int fileCountQuota) {
+    this.fileCountQuota = fileCountQuota;
+  }
+
+  /**
+   * @return true when at least one configuration field is invalid.
+   */
+  public boolean isInvalid() {
+    return isLogFolderInvalid() ||
+            isFileExtensionInvalid() ||
+            isBatchSizeInvalid() ||
+            isReadIntervalInvalid() ||
+            isFileCountQuotaInvalid();
+  }
+
+  /**
+   * Adds error messages to the given {@code contextAware} in case any configuration field is invalid.
+   *
+   * @param contextAware the context aware implementation to add the error messages to
+   */
+  public void addErrors(final ContextAware contextAware) {
+
+    if (isLogFolderInvalid()) {
+      contextAware.addError("logFolder must not be null nor empty");
+    }
+
+    if (isFileExtensionInvalid()) {
+      contextAware.addError("fileExtension must not be null nor empty");
+    }
+
+    if (isBatchSizeInvalid()) {
+      contextAware.addError("batchSize must be greater than zero");
+    }
+
+    if (isReadIntervalInvalid()) {
+      contextAware.addError("readInterval must be greater than zero");
+    }
+
+    if (isFileCountQuotaInvalid()) {
+      contextAware.addError("fileCountQuota must be greater than zero");
+    }
+  }
+
+  /**
+   * Makes sure that the given {@code logFolder} always ends with a file separator.
+   *
+   * @param logFolder the log folder to check
+   * @return a log folder path that always ends with a file separator
+   */
+  private String format(final String logFolder) {
+
+    if (Strings.isNullOrEmpty(logFolder)) {
+      return logFolder;
+    }
+
+    if (logFolder.endsWith(File.separator)) {
+      return logFolder;
+    }
+
+    return logFolder + File.separator;
+  }
+
+  private boolean isLogFolderInvalid() {
+    return Strings.isNullOrEmpty(logFolder);
+  }
+
+  private boolean isFileExtensionInvalid() {
+    return Strings.isNullOrEmpty(fileExtension);
+  }
+
+  private boolean isBatchSizeInvalid() {
+    return batchSize < 1;
+  }
+
+  private boolean isReadIntervalInvalid() {
+    return readInterval < 1;
+  }
+
+  private boolean isFileCountQuotaInvalid() {
+    return fileCountQuota < 1;
+  }
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/FileBufferingSocketAppender.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/FileBufferingSocketAppender.java
@@ -1,0 +1,269 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEventVO;
+import ch.qos.logback.classic.util.Closeables;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.Context;
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.ObjectOutput;
+import java.util.Timer;
+import java.util.UUID;
+
+/**
+ * Buffers log events to disk, so that they can be sent over a socket
+ * according to the specified configuration. The only required configuration is
+ * the {@code logFolder} to buffer events to. In the default configuration, events
+ * will be sent in batches of 50 and in chronological order every minute,
+ * unless the file count quota of 500 is reached, in which
+ * case the oldest events will be dropped.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class FileBufferingSocketAppender extends AppenderBase<ILoggingEvent> {
+
+  private static final String TMP_FILE_EXT = ".tmp";
+
+  private final FileBufferingConfiguration configuration;
+  private final SocketAppender socketAppender;
+  private final LogFileReader logFileReader;
+  private final Timer timer;
+  private final ObjectIOProvider objectIoProvider;
+
+  public FileBufferingSocketAppender() {
+    this(new FileBufferingConfiguration(), new SocketAppender(), new Timer("LogEventReader"), new ObjectIOProvider());
+  }
+
+  private FileBufferingSocketAppender(
+          final FileBufferingConfiguration configuration,
+          final SocketAppender socketAppender,
+          final Timer timer,
+          final ObjectIOProvider objectIoProvider) {
+
+    this(configuration, socketAppender, new LogFileReader(configuration, socketAppender, objectIoProvider), timer, objectIoProvider);
+  }
+
+  FileBufferingSocketAppender(
+          final FileBufferingConfiguration configuration,
+          final SocketAppender socketAppender,
+          final LogFileReader logFileReader,
+          final Timer timer,
+          final ObjectIOProvider objectIoProvider) {
+
+    this.configuration = configuration;
+    this.socketAppender = socketAppender;
+    this.logFileReader = logFileReader;
+    this.timer = timer;
+    this.objectIoProvider = objectIoProvider;
+  }
+
+  @Override
+  public void start() {
+
+    if (configuration.isInvalid()) {
+      configuration.addErrors(this);
+      return;
+    }
+
+    super.start();
+    socketAppender.start();
+
+    removeOldTempFiles();
+
+    timer.schedule(logFileReader, configuration.getReadInterval(), configuration.getReadInterval());
+  }
+
+  @Override
+  protected void append(final ILoggingEvent event) {
+    if (!isStarted()) {
+      return;
+    }
+
+    createLogFolderIfAbsent();
+    socketAppender.postProcessEvent(event);
+
+    boolean savedSuccessfully = false;
+    final String fileName = generateFilePath();
+    final String tempName = fileName + TMP_FILE_EXT;
+    ObjectOutput objectOutput = null;
+    try {
+      objectOutput = objectIoProvider.newObjectOutput(tempName);
+      objectOutput.writeObject(LoggingEventVO.build(event));
+      savedSuccessfully = true;
+    } catch (final IOException e) {
+      addError("Could not write logging event to disk.", e);
+    } finally {
+      Closeables.close(objectOutput);
+    }
+
+    if (savedSuccessfully) {
+      renameFileFromTempToFinalName(tempName, fileName);
+    }
+  }
+
+  @Override
+  public void setName(final String name) {
+    super.setName(name);
+    socketAppender.setName(name + "-BelongingSocketAppender");
+  }
+
+  @Override
+  public void stop() {
+    if (!isStarted()) {
+      return;
+    }
+
+    super.stop();
+    timer.cancel();
+    socketAppender.stop();
+  }
+
+  @Override
+  public void setContext(final Context context) {
+    super.setContext(context);
+    socketAppender.setContext(context);
+  }
+
+  /**
+   * @see SocketAppender#setIncludeCallerData(boolean)
+   */
+  public void setIncludeCallerData(boolean includeCallerData) {
+    socketAppender.setIncludeCallerData(includeCallerData);
+  }
+
+  /**
+   * @see SocketAppender#setRemoteHost(String)
+   */
+  public void setRemoteHost(final String host) {
+    socketAppender.setRemoteHost(host);
+  }
+
+  /**
+   * @see SocketAppender#setPort(int)
+   */
+  public void setPort(final int port) {
+    socketAppender.setPort(port);
+  }
+
+  /**
+   * @see SocketAppender#setReconnectionDelay(int)
+   */
+  public void setReconnectionDelay(final int delay) {
+    socketAppender.setReconnectionDelay(delay);
+  }
+
+  /**
+   * @see SocketAppender#setLazy(boolean)
+   */
+  public void setLazy(final boolean enable) {
+    socketAppender.setLazy(enable);
+  }
+
+  /**
+   * @see FileBufferingConfiguration#setLogFolder(String)
+   */
+  public void setLogFolder(final String logFolder) {
+    configuration.setLogFolder(logFolder);
+  }
+
+  /**
+   * @see FileBufferingConfiguration#setFileExtension(String)
+   */
+  public void setFileEnding(final String fileEnding) {
+    configuration.setFileExtension(fileEnding);
+  }
+
+  /**
+   * @see FileBufferingConfiguration#setBatchSize(int)
+   */
+  public void setBatchSize(final int batchSize) {
+    configuration.setBatchSize(batchSize);
+  }
+
+  /**
+   * @see FileBufferingConfiguration#setReadInterval(long)
+   */
+  public void setReadInterval(final long readInterval) {
+    configuration.setReadInterval(readInterval);
+  }
+
+  /**
+   * @see FileBufferingConfiguration#setFileCountQuota(int)
+   */
+  public void setFileCountQuota(final int fileCountQuota) {
+    configuration.setFileCountQuota(fileCountQuota);
+  }
+
+  /**
+   * Removes old temporary files which might not got removed due to unexpected application shut down.
+   */
+  private void removeOldTempFiles() {
+    final File logFolder = new File(configuration.getLogFolder());
+    final File[] oldTempFiles = logFolder.listFiles(new FileFilter() {
+      @Override
+      public boolean accept(final File file) {
+        return file.isFile() && file.getAbsolutePath().endsWith(TMP_FILE_EXT);
+      }
+    });
+
+    if (oldTempFiles == null) {
+      return;
+    }
+
+    for (final File file : oldTempFiles) {
+      file.delete();
+    }
+  }
+
+  /**
+   * Makes sure that the log folder actually exists.
+   */
+  private void createLogFolderIfAbsent() {
+    final File folder = new File(configuration.getLogFolder());
+    if (!folder.exists()) {
+      folder.mkdirs();
+    }
+  }
+
+  /**
+   * Makes sure each serialized event has it's own unique (UUID-based) file name
+   * and is located in the specified {@code logFolder} and ends with the specified
+   * {@code fileEnding}.
+   *
+   * @return the generated file path
+   */
+  private String generateFilePath() {
+    return configuration.getLogFolder() + UUID.randomUUID() + configuration.getFileExtension();
+  }
+
+  /**
+   * Moves the file from it's temporary name to it's final name.
+   *
+   * @param tempName the temporary name
+   * @param fileName the final name
+   */
+  private void renameFileFromTempToFinalName(final String tempName, final String fileName) {
+    try {
+      Files.move(new File(tempName), new File(fileName));
+    } catch (final IOException e) {
+      addError("Could not rename file from " + tempName + " to " + fileName);
+    }
+  }
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/LogFileReader.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/LogFileReader.java
@@ -1,0 +1,183 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.util.Closeables;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Longs;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TimerTask;
+
+/**
+ * A {@link TimerTask} which works closely together with the {@link FileBufferingSocketAppender} and the
+ * {@link SocketAppender}. It serves as a timed task which will take over the reading of serialized log events
+ * and either send them or delete them according to the provided {@link FileBufferingConfiguration}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class LogFileReader extends TimerTask {
+
+  private final FileBufferingConfiguration configuration;
+  private final SocketAppender appender;
+  private final ObjectIOProvider objectIoProvider;
+
+  public LogFileReader(
+          final FileBufferingConfiguration configuration,
+          final SocketAppender socketAppender,
+          final ObjectIOProvider objectIoProvider) {
+
+    this.configuration = configuration;
+    this.appender = socketAppender;
+    this.objectIoProvider = objectIoProvider;
+  }
+
+  @Override
+  public void run() {
+
+    final List<File> allFilesOrderedByDate = getAllFilesOrderedByDate();
+    final List<File> filesToDelete;
+    final List<File> filesToSend;
+
+    final int size = allFilesOrderedByDate.size();
+    final boolean quotaIsReached = allFilesOrderedByDate.size() > configuration.getFileCountQuota();
+    if (quotaIsReached) {
+      final int lastToBeRemoved = allFilesOrderedByDate.size() - configuration.getFileCountQuota();
+      filesToDelete = Lists.newArrayList(allFilesOrderedByDate.subList(0, lastToBeRemoved));
+      final int lastIndex = Math.min(lastToBeRemoved + configuration.getBatchSize(), size);
+      filesToSend = Lists.newArrayList(allFilesOrderedByDate.subList(lastToBeRemoved, lastIndex));
+    } else {
+      filesToDelete = Collections.emptyList();
+      final int lastIndex = Math.min(configuration.getBatchSize(), size);
+      filesToSend = Lists.newArrayList(allFilesOrderedByDate.subList(0, lastIndex));
+    }
+
+    delete(filesToDelete);
+    send(filesToSend);
+  }
+
+  /**
+   * Deletes the given {@code files}.
+   *
+   * @param files the files to delete
+   */
+  private void delete(final List<File> files) {
+    for (final File file : files) {
+      file.delete();
+    }
+  }
+
+  /**
+   * Tries to send the given {@code files} over the socket. Each successfully sent operation
+   * will automatically delete the serialized version of the event. In the unlikely event
+   * that a file could not be read, the file is assumed to be broken and will also be deleted.
+   *
+   * @param files the files to be sent
+   */
+  private void send(final List<File> files) {
+
+    for (final File file : files) {
+      final Optional<ILoggingEvent> loggingEvent = deserialize(file);
+
+      final boolean couldNotReadLoggingEvent = !loggingEvent.isPresent();
+      if (couldNotReadLoggingEvent) {
+        appender.addWarn("Deserialization for logging event at " + file.getAbsolutePath() + " failed. Deleting file.");
+        file.delete();
+        continue;
+      }
+
+      if (appender.isConnecting()) {
+        return;
+      }
+
+      final boolean sendSuccessful = appender.tryAppend(loggingEvent.get());
+
+      if (sendSuccessful) {
+        file.delete();
+      }
+    }
+  }
+
+  /**
+   * De-serializes the given file into a instance of {@link ILoggingEvent}.
+   * The result is an optional, meaning that in case the de-serialization failed
+   * an "absent" is returned.
+   *
+   * @param file the file to de-serialize
+   * @return an {@link Optional} of a {@link File}
+   */
+  private Optional<ILoggingEvent> deserialize(final File file) {
+
+    ObjectInput objectInput = null;
+    try {
+      objectInput = objectIoProvider.newObjectInput(file);
+      final ILoggingEvent loggingEvent = (ILoggingEvent) objectInput.readObject();
+      return Optional.of(loggingEvent);
+    } catch (final FileNotFoundException e) {
+      appender.addError("Could not find logging event on disk.", e);
+    } catch (final ClassNotFoundException e) {
+      appender.addError("Could not de-serialize logging event from disk.", e);
+    } catch (final IOException e) {
+      appender.addError("Could not load logging event from disk.", e);
+    } finally {
+      Closeables.close(objectInput);
+    }
+
+    return Optional.absent();
+  }
+
+  /**
+   * Retrieves all files which end with the specified file extension
+   * located in the specified folder in chronological order.
+   *
+   * @return a list of files which matches the criteria, might be empty
+   */
+  private List<File> getAllFilesOrderedByDate() {
+    final File logFolder = new File(configuration.getLogFolder());
+    final File[] files = logFolder.listFiles(new FileFilter() {
+      @Override
+      public boolean accept(final File file) {
+        return file.isFile() && file.getName().endsWith(configuration.getFileExtension());
+      }
+    });
+
+    if (files == null) {
+      return Collections.emptyList();
+    }
+
+    final List<File> ordered = Lists.newArrayList(files);
+
+    Collections.sort(ordered, new Comparator<File>() {
+      @Override
+      public int compare(final File lhs, final File rhs) {
+
+        final long lhsLastModified = lhs.lastModified();
+        final long rhsLastModified = rhs.lastModified();
+
+        return Longs.compare(lhsLastModified, rhsLastModified);
+      }
+    });
+
+    return ordered;
+  }
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/net/ObjectIOProvider.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/net/ObjectIOProvider.java
@@ -1,0 +1,53 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+
+/**
+ * Provides inputs and outputs for objects to and from files.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class ObjectIOProvider {
+
+  /**
+   * Creates a new {@link ObjectOutput} for the given {@code fileName}.
+   *
+   * @param fileName the name of the file for which the output should be created
+   * @return a new instance of {@link ObjectOutput}
+   * @throws IOException when an exception occurred during the creation of the stream
+   */
+  public ObjectOutput newObjectOutput(final String fileName) throws IOException {
+    return new ObjectOutputStream(new FileOutputStream(fileName));
+  }
+
+  /**
+   * Creates a new {@link ObjectInput} for the given {@code file}.
+   *
+   * @param file the file for which the input should be cerated
+   * @return a new instance of {@link ObjectInput}
+   * @throws IOException when an exception occurred during the creation of the stream
+   */
+  public ObjectInput newObjectInput(final File file) throws IOException {
+    return new ObjectInputStream(new FileInputStream(file));
+  }
+}

--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/Closeables.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/Closeables.java
@@ -1,0 +1,69 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.util;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+
+/**
+ * Provides convenience methods to close I/O objects.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public final class Closeables {
+
+  private Closeables() {
+    // no public instantiation allowed
+  }
+
+  /**
+   * Gracefully closes given {@code objectInput}, disregarding
+   * if the given object is {@code null} or its close method throws
+   * an {@link IOException}.
+   *
+   * @param objectInput the {@link ObjectOutput} to close
+   */
+  public static void close(final ObjectInput objectInput) {
+    if (objectInput == null) {
+      return;
+    }
+
+    try {
+      objectInput.close();
+    } catch (final IOException e) {
+      // ignored
+    }
+  }
+
+  /**
+   * Gracefully closes given {@code objectOutput}, disregarding
+   * if the given object is {@code null} or its close method throws
+   * an {@link IOException}.
+   *
+   * @param objectOutput the {@link ObjectOutput} to close
+   */
+  public static void close(final ObjectOutput objectOutput) {
+    if (objectOutput == null) {
+      return;
+    }
+
+    try {
+      objectOutput.close();
+    } catch (final IOException e) {
+      // ignored
+    }
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/FileBufferingConfigurationTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/FileBufferingConfigurationTest.java
@@ -1,0 +1,193 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.core.spi.ContextAware;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * @author Sebastian Gr&ouml;bler
+ */
+public class FileBufferingConfigurationTest {
+
+  private final FileBufferingConfiguration configuration = new FileBufferingConfiguration();
+
+  @Test
+  public void hasDefaultValueForFileExtension() {
+    assertThat(configuration.getFileExtension(), is(FileBufferingConfiguration.DEFAULT_FILE_EXT));
+  }
+
+  @Test
+  public void hasNoDefaultValueForLogFolder() {
+    assertThat(configuration.getLogFolder(), is(nullValue()));
+  }
+
+  @Test
+  public void hasDefaultValueForBatchSize() {
+    assertThat(configuration.getBatchSize(), is(FileBufferingConfiguration.DEFAULT_BATCH_SIZE));
+  }
+
+  @Test
+  public void hasDefaultValueForReadInterval() {
+    assertThat(configuration.getReadInterval(), is(FileBufferingConfiguration.DEFAULT_READ_INTERVAL));
+  }
+
+  @Test
+  public void hasDefaultValueForFileCountQuota() {
+    assertThat(configuration.getFileCountQuota(), is(FileBufferingConfiguration.DEFAULT_FILE_COUNT_QUOTA));
+  }
+
+  @Test
+  public void isValidWithDefaultValues() {
+
+    configuration.setLogFolder("/some/folder/");
+
+    assertThat(configuration.isInvalid(), is(false));
+  }
+
+  @Test
+  public void doesNotAddErrorForDefaultValues() {
+
+    //given
+    configuration.setLogFolder("/some/folder/");
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verifyZeroInteractions(contextAware);
+  }
+
+  @Test
+  public void addsTrailingSlashToLogFolderIfMissing() {
+    configuration.setLogFolder("/some/folder");
+
+    assertThat(configuration.getLogFolder(), is("/some/folder/"));
+  }
+
+  @Test
+  public void isInvalidWhenLogFolderIsNull() {
+    configuration.setLogFolder(null);
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenLogFolderIsEmpty() {
+    configuration.setLogFolder("");
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenFileExtensionIsNull() {
+    configuration.setFileExtension(null);
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenFileExtensionIsEmpty() {
+    configuration.setFileExtension("");
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenBatchSizeIsSmallerThanOne() {
+    configuration.setBatchSize(0);
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenReadIntervalIsSmallerThanOne() {
+    configuration.setReadInterval(0);
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void isInvalidWhenFileCountQuotaIsSmallerThanOne() {
+    configuration.setFileCountQuota(0);
+    assertThat(configuration.isInvalid(), is(true));
+  }
+
+  @Test
+  public void addsErrorWhenLogFolderIsInvalid() {
+    // given
+    configuration.setLogFolder(null);
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verify(contextAware).addError("logFolder must not be null nor empty");
+  }
+
+  @Test
+  public void addsErrorWhenFileExtensionIsInvalid() {
+    // given
+    configuration.setFileExtension(null);
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verify(contextAware).addError("fileExtension must not be null nor empty");
+  }
+
+  @Test
+  public void addsErrorWhenBatchSizeIsInvalid() {
+    // given
+    configuration.setBatchSize(0);
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verify(contextAware).addError("batchSize must be greater than zero");
+  }
+
+  @Test
+  public void addsErrorWhenReadIntervalIsInvalid() {
+    // given
+    configuration.setReadInterval(0);
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verify(contextAware).addError("readInterval must be greater than zero");
+  }
+
+  @Test
+  public void addsErrorWhenFileCountQuotaIsInvalid() {
+    // given
+    configuration.setFileCountQuota(0);
+    final ContextAware contextAware = mock(ContextAware.class);
+
+    // when
+    configuration.addErrors(contextAware);
+
+    // then
+    verify(contextAware).addError("fileCountQuota must be greater than zero");
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/FileBufferingSocketAppenderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/FileBufferingSocketAppenderTest.java
@@ -1,0 +1,516 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.classic.net.testObjectBuilders.MockLoggingEvent;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEventVO;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.status.StatusManager;
+import com.google.common.base.Strings;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.util.Timer;
+import org.fest.util.Files;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import static ch.qos.logback.classic.net.testObjectBuilders.SerializedLogFileFactory.addFile;
+import static ch.qos.logback.matchers.StatusMatchers.containsMessage;
+import static ch.qos.logback.matchers.StatusMatchers.hasLevel;
+import static ch.qos.logback.matchers.StatusMatchers.hasNoItemWhichContainsMessage;
+import static ch.qos.logback.matchers.StatusMatchers.hasThrowable;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Sebastian Gr&ouml;bler
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FileBufferingSocketAppenderTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Mock
+  private SocketAppender socketAppender;
+
+  @Mock
+  private LogFileReader logFileReader;
+
+  @Spy
+  private FileBufferingConfiguration configuration = new FileBufferingConfiguration();
+
+  @Mock
+  private ObjectIOProvider objectIoProvider;
+
+  @Mock
+  private Timer timer;
+
+  @InjectMocks
+  private FileBufferingSocketAppender appender;
+
+
+  private ObjectOutput objectOutput;
+
+  @Before
+  public void beforeEachTest() {
+    configuration.setLogFolder("/some/folder/");
+  }
+
+  @Test
+  public void doesNotStartWhenConfigurationIsInvalid() {
+
+    // given
+    when(configuration.isInvalid()).thenReturn(Boolean.TRUE);
+
+    // when
+    appender.start();
+
+    // then
+    assertThat(appender.isStarted(), is(false));
+  }
+
+  @Test
+  public void addsErrorsWhenConfigurationIsInvalid() {
+
+    // given
+    when(configuration.isInvalid()).thenReturn(Boolean.TRUE);
+
+    // when
+    appender.start();
+
+    // then
+    verify(configuration).addErrors(appender);
+  }
+
+
+  @Test
+  public void doesNotStopWhenNotStarted() {
+    appender.stop();
+
+    verify(timer, never()).cancel();
+    verify(socketAppender, never()).stop();
+  }
+
+  @Test
+  public void logsErrorOnIOException() throws IOException {
+
+    // given
+    final StatusManager statusManager = mockStatusManager();
+    final ILoggingEvent event = mock(ILoggingEvent.class);
+    when(objectIoProvider.newObjectOutput(anyString())).thenThrow(IOException.class);
+
+    // when
+    appender.start();
+    appender.append(event);
+
+    // then
+    final ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
+    verify(statusManager).add(captor.capture());
+
+    final Status status = captor.getValue();
+    assertThat(status, containsMessage("Could not write logging event to disk."));
+    assertThat(status, hasLevel(Status.ERROR));
+    assertThat(status, hasThrowable(IOException.class));
+  }
+
+  @Test
+  public void startsTimerWithConfiguredIntervalOnStart() {
+    appender.start();
+
+    verify(timer).schedule(logFileReader, configuration.getReadInterval(), configuration.getReadInterval());
+  }
+
+  @Test
+  public void stopsTimerOnStop() {
+    // given
+    appender.start();
+
+    // when
+    appender.stop();
+
+    // then
+    verify(timer).cancel();
+  }
+
+  @Test
+  public void doesNotAppendIfNotStarted() {
+    appender.append(mock(ILoggingEvent.class));
+    verifyZeroInteractions(objectIoProvider);
+  }
+
+  @Test
+  public void serializesEventToConfiguredFolder() throws IOException {
+    // given
+    final String logFolder = folder.getRoot().getAbsolutePath() + "/foo/";
+    appender.setLogFolder(logFolder);
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    assertThat(new File(logFolder).list(), hasItemInArray(endsWith(configuration.getFileExtension())));
+  }
+
+  @Test
+  public void createsMissingDirsWithEveryLoggingEvent() throws IOException {
+    // given
+    final StatusManager statusManager = mockStatusManager();
+    appender.setLogFolder(folder.getRoot().getAbsolutePath() + "/foo");
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    Files.delete(new File(configuration.getLogFolder()));
+
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    verifyZeroInteractions(statusManager);
+  }
+
+  @Test
+  public void closesStreamsOnSuccessfulFileWrite() throws IOException {
+    // given
+    appender.setLogFolder(folder.getRoot().getAbsolutePath() + "/foo/");
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    verify(objectOutput).close();
+  }
+
+  @Test
+  public void closesStreamsOnUnsuccessfulFileWrite() throws IOException {
+    // given
+    appender.setLogFolder(folder.getRoot().getAbsolutePath() + "/foo/");
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createExceptionThrowingObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    verify(objectOutput).close();
+  }
+
+  @Test
+  public void allowsFolderToHaveTrailingSlash() throws IOException {
+    // given
+    final String logFolder = folder.getRoot().getAbsolutePath() + "/foo/";
+    appender.setLogFolder(logFolder);
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    assertThat(new File(logFolder).list(), hasItemInArray(endsWith(configuration.getFileExtension())));
+  }
+
+  @Test
+  public void allowsFolderToHaveNoTrailingSlash() throws IOException {
+    // given
+    final String logFolder = folder.getRoot().getAbsolutePath() + "/foo";
+    appender.setLogFolder(logFolder);
+
+    when(objectIoProvider.newObjectOutput(anyString())).then(createObjectOutput());
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    assertThat(new File(logFolder).list(), hasItemInArray(endsWith(configuration.getFileExtension())));
+  }
+
+  @Test
+  public void loadsCallerDataWhenConfigured() throws IOException {
+
+    // given
+    appender.setIncludeCallerData(true);
+    objectOutput = mock(ObjectOutput.class);
+    when(objectIoProvider.newObjectOutput(anyString())).thenReturn(objectOutput);
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    verify(socketAppender).postProcessEvent(any(ILoggingEvent.class));
+  }
+
+  @Test
+  public void doesNotLoadCallerDataWhenConfigured() throws IOException {
+
+    // given
+    appender.setIncludeCallerData(false);
+    objectOutput = mock(ObjectOutput.class);
+    when(objectIoProvider.newObjectOutput(anyString())).thenReturn(objectOutput);
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create());
+
+    // then
+    final ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+    verify(objectOutput).writeObject(captor.capture());
+
+    final LoggingEventVO loggingEventVO = (LoggingEventVO) captor.getValue();
+
+    assertThat(loggingEventVO.hasCallerData(), is(false));
+  }
+
+  @Test
+  public void givesFilesSpecialTemporaryFileEndingWhileWritingToAvoidSimultaneousReadAndWrite() throws IOException {
+
+    // given
+    final FileBufferingSocketAppender appender = new FileBufferingSocketAppender();
+    final Context context = mock(Context.class);
+    final StatusManager statusManager = mock(StatusManager.class);
+    when(context.getStatusManager()).thenReturn(statusManager);
+
+    final String logFolder = folder.getRoot().getAbsolutePath() + "/foo/";
+    appender.setLogFolder(logFolder);
+    appender.setPort(6000);
+    appender.setRemoteHost("localhost");
+    appender.setContext(context);
+    appender.setLazy(true);
+    appender.setReadInterval(10);
+
+    // when
+    appender.start();
+    appender.append(MockLoggingEvent.create().withMessage(Strings.repeat("some random string", 1000000)));
+    appender.stop();
+
+    // then
+    final ArgumentCaptor<Status> captor = ArgumentCaptor.forClass(Status.class);
+    verify(statusManager, atLeast(0)).add(captor.capture());
+
+    assertThat(captor.getAllValues(), hasNoItemWhichContainsMessage("Could not load logging event from disk."));
+  }
+
+  @Test
+  public void removesOldTempFilesOnStart() throws IOException {
+    // given
+    final String logFolderPath = folder.getRoot().getAbsolutePath() + "/foo/";
+    final File logFolder = new File(logFolderPath);
+    logFolder.mkdirs();
+    appender.setLogFolder(logFolderPath);
+
+    addFile(logFolder.getAbsolutePath() + "/foo.ser.tmp", DateTime.now());
+    addFile(logFolder.getAbsolutePath() + "/bar.ser.tmp", DateTime.now());
+
+    // when
+    appender.start();
+
+    // then
+    assertThat(logFolder.list(), not(hasItemInArray("foo.ser.tmp")));
+    assertThat(logFolder.list(), not(hasItemInArray("bar.ser.tmp")));
+  }
+
+  @Test
+  public void removesOnlyOldTempFilesButNotDirectoriesOnStart() throws IOException {
+    // given
+    final String logFolderPath = folder.getRoot().getAbsolutePath() + "/foo/";
+    final File logFolder = new File(logFolderPath);
+    logFolder.mkdirs();
+    appender.setLogFolder(logFolderPath);
+
+    final File tmpFolder = new File(logFolderPath + "/some.tmp");
+    tmpFolder.mkdirs();
+
+    // when
+    appender.start();
+
+    // then
+    assertThat(logFolder.list(), hasItemInArray("some.tmp"));
+  }
+
+  @Test
+  public void removalOfOldTempFilesOnStartCanHandleNonExistingTempFolder() {
+    // given
+    appender.setLogFolder(folder.getRoot().getAbsolutePath() + "/foo/");
+
+    // when
+    appender.start();
+  }
+
+  @Test
+  public void delegatesContextToSocketAppender() {
+
+    // given
+    final Context context = mock(Context.class);
+
+    // when
+    appender.setContext(context);
+
+    // then
+    verify(socketAppender).setContext(context);
+  }
+
+  @Test
+  public void setsNameToSocketAppender() {
+    appender.setName("SomeName");
+    verify(socketAppender).setName("SomeName-BelongingSocketAppender");
+  }
+
+  @Test
+  public void startsSocketAppender() {
+    appender.start();
+    verify(socketAppender).start();
+  }
+
+  @Test
+  public void stopsSocketAppender() {
+    appender.start();
+    appender.stop();
+
+    verify(socketAppender).stop();
+  }
+
+  @Test
+  public void delegatesIncludeCallerDataToSocketAppender() {
+    appender.setIncludeCallerData(false);
+    verify(socketAppender).setIncludeCallerData(false);
+  }
+
+  @Test
+  public void delegatesRemoteHostToSocketAppender() {
+    appender.setRemoteHost("localhost");
+    verify(socketAppender).setRemoteHost("localhost");
+  }
+
+  @Test
+  public void delegatesPortToSocketAppender() {
+    appender.setPort(8081);
+    verify(socketAppender).setPort(8081);
+  }
+
+  @Test
+  public void delegatesReconnectionDelayToSocketAppender() {
+    appender.setReconnectionDelay(1000);
+    verify(socketAppender).setReconnectionDelay(1000);
+  }
+
+  @Test
+  public void delegatesLazyToSocketAppender() {
+    appender.setLazy(true);
+    verify(socketAppender).setLazy(true);
+  }
+
+  @Test
+  public void delegatesLogFolderToConfiguration() {
+    appender.setLogFolder("/foo/bar/");
+    verify(configuration).setLogFolder("/foo/bar/");
+  }
+
+  @Test
+  public void delegatesFileEndingToConfiguration() {
+    appender.setFileEnding(".foobar");
+    verify(configuration).setFileExtension(".foobar");
+  }
+
+  @Test
+  public void delegatesBatchSizeToConfiguration() {
+    appender.setBatchSize(1000);
+    verify(configuration).setBatchSize(1000);
+  }
+
+  @Test
+  public void delegatesReadIntervalToConfiguration() {
+    appender.setReadInterval(5000);
+    verify(configuration).setReadInterval(5000);
+  }
+
+  @Test
+  public void delegatesFileCountQuotaToConfiguration() {
+    appender.setFileCountQuota(1000);
+    verify(configuration).setFileCountQuota(1000);
+  }
+
+  private StatusManager mockStatusManager() {
+    final Context context = mock(Context.class);
+    final StatusManager statusManager = mock(StatusManager.class);
+    appender.setContext(context);
+    when(context.getStatusManager()).thenReturn(statusManager);
+    return statusManager;
+  }
+
+  private Answer<?> createExceptionThrowingObjectOutput() {
+    return new Answer<Object>() {
+      @Override
+      public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final String fileName = (String) invocation.getArguments()[0];
+        objectOutput = spy(new ObjectOutputStream(new FileOutputStream(fileName)));
+        doThrow(IOException.class).when(objectOutput).writeObject(any(Object.class));
+        return objectOutput;
+      }
+    };
+  }
+
+  private Answer<Object> createObjectOutput() {
+    return new Answer<Object>() {
+      @Override
+      public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final String fileName = (String) invocation.getArguments()[0];
+        objectOutput = spy(new ObjectOutputStream(new FileOutputStream(fileName)));
+        return objectOutput;
+      }
+    };
+  }
+
+
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/LogFileReaderTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/LogFileReaderTest.java
@@ -1,0 +1,346 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net;
+
+import ch.qos.logback.classic.net.testObjectBuilders.MockLoggingEvent;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import static ch.qos.logback.classic.net.testObjectBuilders.SerializedLogFileFactory.addFile;
+import static ch.qos.logback.matchers.LoggingEventMatchers.containsMessage;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.collection.IsArrayContaining.hasItemInArray;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+/**
+ * @author Sebastian Gr&ouml;bler
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class LogFileReaderTest {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Mock
+  private SocketAppender appender;
+
+  @Spy
+  private FileBufferingConfiguration configuration = new FileBufferingConfiguration();
+
+  @Mock
+  private ObjectIOProvider objectIoProvider;
+
+  @InjectMocks
+  private LogFileReader logFileReader;
+
+  private File logFolder;
+
+  @Before
+  public void beforeEachTest() throws IOException {
+    final String logFolderPath = folder.getRoot().getAbsolutePath() + "/foo/";
+    logFolder = new File(logFolderPath);
+    logFolder.mkdirs();
+
+    when(configuration.getLogFolder()).thenReturn(logFolderPath);
+    when(appender.tryAppend(any(ILoggingEvent.class))).thenReturn(Boolean.TRUE);
+  }
+
+  @Test
+  public void deletesOldestEventsWhichAreOverTheQuota() throws IOException {
+
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    when(configuration.getFileCountQuota()).thenReturn(3);
+    when(configuration.getBatchSize()).thenReturn(0);
+    addFile(toPath("a.ser"), DateTime.now().plusMinutes(1));
+    addFile(toPath("b.ser"), DateTime.now().plusMinutes(2));
+    addFile(toPath("c.ser"), DateTime.now().plusMinutes(3));
+    addFile(toPath("d.ser"), DateTime.now().plusMinutes(4));
+    addFile(toPath("e.ser"), DateTime.now().plusMinutes(5));
+
+    // when
+    logFileReader.run();
+
+    // then
+    assertThat(logFolder.list(), not(hasItemInArray("a.ser")));
+    assertThat(logFolder.list(), not(hasItemInArray("b.ser")));
+    assertThat(logFolder.list(), hasItemInArray("c.ser"));
+    assertThat(logFolder.list(), hasItemInArray("d.ser"));
+    assertThat(logFolder.list(), hasItemInArray("e.ser"));
+  }
+
+  @Test
+  public void sendsOldestEventsFirst() throws IOException {
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    addFile(MockLoggingEvent.create().withMessage("a"), toPath("a.ser"), DateTime.now().plusMinutes(1));
+    addFile(MockLoggingEvent.create().withMessage("b"), toPath("b.ser"), DateTime.now().plusMinutes(2));
+    addFile(MockLoggingEvent.create().withMessage("c"), toPath("c.ser"), DateTime.now().plusMinutes(3));
+    addFile(MockLoggingEvent.create().withMessage("d"), toPath("d.ser"), DateTime.now().plusMinutes(4));
+    addFile(MockLoggingEvent.create().withMessage("e"), toPath("e.ser"), DateTime.now().plusMinutes(5));
+
+    // when
+    logFileReader.run();
+
+    // then
+    final ArgumentCaptor<ILoggingEvent> captor = ArgumentCaptor.forClass(ILoggingEvent.class);
+    verify(appender, times(5)).tryAppend(captor.capture());
+
+    assertThat(captor.getAllValues().get(0), containsMessage("a"));
+    assertThat(captor.getAllValues().get(1), containsMessage("b"));
+    assertThat(captor.getAllValues().get(2), containsMessage("c"));
+    assertThat(captor.getAllValues().get(3), containsMessage("d"));
+    assertThat(captor.getAllValues().get(4), containsMessage("e"));
+  }
+
+  @Test
+  public void onlySendsTheConfiguredBatchSize() throws IOException {
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    when(configuration.getBatchSize()).thenReturn(3);
+    addFile(MockLoggingEvent.create().withMessage("a"), toPath("a.ser"), DateTime.now().plusMinutes(1));
+    addFile(MockLoggingEvent.create().withMessage("b"), toPath("b.ser"), DateTime.now().plusMinutes(2));
+    addFile(MockLoggingEvent.create().withMessage("c"), toPath("c.ser"), DateTime.now().plusMinutes(3));
+    addFile(MockLoggingEvent.create().withMessage("d"), toPath("d.ser"), DateTime.now().plusMinutes(4));
+    addFile(MockLoggingEvent.create().withMessage("e"), toPath("e.ser"), DateTime.now().plusMinutes(5));
+
+    // when
+    logFileReader.run();
+
+    // then
+    final ArgumentCaptor<ILoggingEvent> captor = ArgumentCaptor.forClass(ILoggingEvent.class);
+    verify(appender, times(3)).tryAppend(captor.capture());
+
+    assertThat(captor.getAllValues().get(0), containsMessage("a"));
+    assertThat(captor.getAllValues().get(1), containsMessage("b"));
+    assertThat(captor.getAllValues().get(2), containsMessage("c"));
+  }
+
+  @Test
+  public void doesNotSendEventsWhenAppenderIsConnecting() throws IOException {
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    when(appender.isConnecting()).thenReturn(Boolean.TRUE);
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(appender, times(0)).tryAppend(any(ILoggingEvent.class));
+  }
+
+  @Test
+  public void deletesEventWhichCouldNotBeDeserialized() throws IOException, ClassNotFoundException {
+    // given
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(IOException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    assertThat(logFolder.list(), arrayWithSize(0));
+  }
+
+  @Test
+  public void onlyDeletesEventsWhenNoIOExceptionOccurredDuringTransmission() throws IOException {
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    when(appender.tryAppend(any(ILoggingEvent.class))).thenReturn(Boolean.FALSE);
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    assertThat(logFolder.list(), hasItemInArray("a.ser"));
+  }
+
+  @Test
+  public void logsWarningWhenEventCouldNotBeDeserialized() throws IOException, ClassNotFoundException {
+    // given
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(IOException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(appender).addWarn(matches("^Deserialization for logging event at (\\S+)/foo/a.ser failed. Deleting file.$"));
+  }
+
+  @Test
+  public void logsErrorWhenEventFileCouldNotBeFound() throws IOException, ClassNotFoundException {
+    // given
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(FileNotFoundException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(appender).addError(eq("Could not find logging event on disk."), any(FileNotFoundException.class));
+  }
+
+  @Test
+  public void logsErrorWhenILoggingEventCouldNotBeFound() throws IOException, ClassNotFoundException {
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(ClassNotFoundException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(appender).addError(eq("Could not de-serialize logging event from disk."), any(ClassNotFoundException.class));
+  }
+
+  @Test
+  public void logsErrorsWhenDeserializationFailedDueToIOException() throws IOException, ClassNotFoundException {
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(IOException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(appender).addError(eq("Could not load logging event from disk."), any(IOException.class));
+  }
+
+  @Test
+  public void closesStreamOnSuccessfulFileRead() throws IOException, ClassNotFoundException {
+
+    // given
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectInput.readObject()).thenReturn(mock(ILoggingEvent.class));
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(objectInput).close();
+  }
+
+  @Test
+  public void closesStreamOnUnsuccessfulFileRead() throws IOException, ClassNotFoundException {
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    when(objectIoProvider.newObjectInput(any(File.class))).thenReturn(objectInput);
+    when(objectInput.readObject()).thenThrow(IOException.class);
+
+    addFile(toPath("a.ser"), DateTime.now());
+
+    // when
+    logFileReader.run();
+
+    // then
+    verify(objectInput).close();
+  }
+
+  @Test
+  public void onlyReadsFilesWithTheConfiguredFileEnding() throws IOException {
+    // given
+    when(objectIoProvider.newObjectInput(any(File.class))).thenAnswer(newObjectInput());
+    addFile(toPath("a.ser"), DateTime.now().plusMinutes(1));
+    addFile(toPath("foo.bar"), DateTime.now().plusMinutes(2));
+
+    // when
+    logFileReader.run();
+
+    // then
+    assertThat(logFolder.list(), hasItemInArray("foo.bar"));
+  }
+
+  @Test
+  public void canHandleEmptyLogFolder() throws IOException {
+    // when
+    logFileReader.run();
+
+    // then
+    verifyZeroInteractions(objectIoProvider);
+    verify(appender, never()).tryAppend(any(ILoggingEvent.class));
+  }
+
+  @Test
+  public void canHandleNonExistingLogFolder() throws IOException {
+    // given
+    when(configuration.getLogFolder()).thenReturn("noLogFolderName");
+
+    // when
+    logFileReader.run();
+
+    // then
+    verifyZeroInteractions(objectIoProvider);
+    verify(appender, never()).tryAppend(any(ILoggingEvent.class));
+  }
+
+  private String toPath(final String fileName) {
+    return logFolder.getAbsolutePath() + "/" + fileName;
+  }
+
+  private Answer<?> newObjectInput() {
+    return new Answer<Object>() {
+      @Override
+      public Object answer(final InvocationOnMock invocation) throws Throwable {
+        final File file = (File) invocation.getArguments()[0];
+        final ObjectInputStream objectInputStream = new ObjectInputStream(new FileInputStream(file));
+        return objectInputStream;
+      }
+    };
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/testObjectBuilders/MockLoggingEvent.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/testObjectBuilders/MockLoggingEvent.java
@@ -1,0 +1,186 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net.testObjectBuilders;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A POJO-like implementation of the {@link ILoggingEvent} which allows
+ * easy creation of valid logging events, which might be altered through the
+ * public setters or the fluent-setters.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class MockLoggingEvent implements ILoggingEvent {
+
+  /**
+   * @return a new instance of {@link MockLoggingEvent} with some reasonable default values set
+   */
+  public static MockLoggingEvent create() {
+    return new MockLoggingEvent();
+  }
+
+  private String threadName = "some thread name";
+  private Level level = Level.DEBUG;
+  private String message = "some message";
+  private Object[] argumentArray = new Object[0];
+  private String formattedMessage = "some formatted message";
+  private String loggerName = "some logger name";
+  private LoggerContextVO loggerContextVO = new LoggerContextVO("some name", new HashMap<String, String>(), 0);
+  private StackTraceElement[] stackTraceElements;
+  private HashMap<String, String> mdcPropertyMap = new HashMap<String, String>();
+  private int timeStamp = 0;
+
+  public MockLoggingEvent withThreadName(String threadName) {
+    this.threadName = threadName;
+    return this;
+  }
+
+  public MockLoggingEvent withLevel(Level level) {
+    this.level = level;
+    return this;
+  }
+
+  public MockLoggingEvent withMessage(String message) {
+    this.message = message;
+    return this;
+  }
+
+  public MockLoggingEvent withArgumentArray(Object[] argumentArray) {
+    this.argumentArray = argumentArray;
+    return this;
+  }
+
+  public MockLoggingEvent withFormattedMessage(String formattedMessage) {
+    this.formattedMessage = formattedMessage;
+    return this;
+  }
+
+  public MockLoggingEvent withLoggerName(String loggerName) {
+    this.loggerName = loggerName;
+    return this;
+  }
+
+  public MockLoggingEvent withLoggerContextVO(LoggerContextVO loggerContextVO) {
+    this.loggerContextVO = loggerContextVO;
+    return this;
+  }
+
+  public MockLoggingEvent withStackTraceElements(StackTraceElement[] stackTraceElements) {
+    this.stackTraceElements = stackTraceElements;
+    return this;
+  }
+
+  public MockLoggingEvent withMdcPropertyMap(HashMap<String, String> mdcPropertyMap) {
+    this.mdcPropertyMap = mdcPropertyMap;
+    return this;
+  }
+
+  public MockLoggingEvent withTimeStamp(int timeStamp) {
+    this.timeStamp = timeStamp;
+    return this;
+  }
+
+  @Override
+  public String getThreadName() {
+    return threadName;
+  }
+
+  @Override
+  public Level getLevel() {
+    return level;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public Object[] getArgumentArray() {
+    return argumentArray;
+  }
+
+  @Override
+  public String getFormattedMessage() {
+    return formattedMessage;
+  }
+
+  @Override
+  public String getLoggerName() {
+    return loggerName;
+  }
+
+  @Override
+  public LoggerContextVO getLoggerContextVO() {
+    return loggerContextVO;
+  }
+
+  @Override
+  public IThrowableProxy getThrowableProxy() {
+    return null;
+  }
+
+  @Override
+  public StackTraceElement[] getCallerData() {
+
+    if (stackTraceElements == null) {
+      stackTraceElements = new StackTraceElement[]{new StackTraceElement("ClassName", "MethodName", "FileName", 1)};
+    }
+
+    return stackTraceElements;
+  }
+
+  @Override
+  public boolean hasCallerData() {
+
+    if (stackTraceElements == null) {
+      return false;
+    }
+
+    return getCallerData().length > 0;
+  }
+
+  @Override
+  public Marker getMarker() {
+    return null;
+  }
+
+  @Override
+  public Map<String, String> getMDCPropertyMap() {
+    return mdcPropertyMap;
+  }
+
+  @Override
+  public Map<String, String> getMdc() {
+    return getMDCPropertyMap();
+  }
+
+  @Override
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+
+  @Override
+  public void prepareForDeferredProcessing() {
+    // NOOP
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/net/testObjectBuilders/SerializedLogFileFactory.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/net/testObjectBuilders/SerializedLogFileFactory.java
@@ -1,0 +1,70 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.net.testObjectBuilders;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEventVO;
+import ch.qos.logback.classic.util.Closeables;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import org.joda.time.DateTime;
+
+/**
+ * Allows to easily create serialized log events by utilizing the {@link MockLoggingEvent}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class SerializedLogFileFactory {
+
+  /**
+   * Creates a file which is a serialized version of the {@link ch.qos.logback.classic.net.testObjectBuilders.MockLoggingEvent#create()}
+   * result at the given {@code filePath} and with the specified {@code lastModified}.
+   *
+   * @param filePath the path under which de logging event should be saved
+   * @param lastModified the date and time of the last modification of the file
+   * @throws IOException when an exception occurred during the creation of the file
+   */
+  public static void addFile(final String filePath, final DateTime lastModified) throws IOException {
+    addFile(MockLoggingEvent.create(), filePath, lastModified);
+  }
+
+  /**
+   * Serializes the given {@code loggingEvent} to a file at the specified {@code filePath} with the specified
+   * {@code lastModified}.
+   *
+   * @param loggingEvent the implementation of {@link ILoggingEvent} to serialize to file
+   * @param filePath the path to serialize the logging event to
+   * @param lastModified the date and time of the last modification of the file
+   * @throws IOException when an exception occurred during the creation of the file
+   */
+  public static void addFile(
+          final ILoggingEvent loggingEvent,
+          final String filePath,
+          final DateTime lastModified) throws IOException {
+
+    ObjectOutput objectOutput = null;
+    try {
+      objectOutput = new ObjectOutputStream(new FileOutputStream(filePath));
+      objectOutput.writeObject(LoggingEventVO.build(loggingEvent));
+    } finally {
+      Closeables.close(objectOutput);
+    }
+
+    final File file = new File(filePath);
+    file.setLastModified(lastModified.getMillis());
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/CloseablesTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/CloseablesTest.java
@@ -1,0 +1,55 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Sebastian Gr&ouml;bler
+ */
+public class CloseablesTest {
+
+  @Test
+  public void closeOfObjectInputIsGracefulToNullValue() {
+    Closeables.close((ObjectInput) null);
+  }
+
+  @Test
+  public void closeOfObjectInputIsGracefulToIOException() throws IOException {
+    final ObjectInput objectInput = mock(ObjectInput.class);
+    doThrow(IOException.class).when(objectInput).close();
+
+    Closeables.close(objectInput);
+  }
+
+  @Test
+  public void closeOfObjectOutputIsGracefulToNullValue() {
+    Closeables.close((ObjectOutput) null);
+  }
+
+  @Test
+  public void closeOfObjectOutputIsGracefulToIOException() throws IOException {
+    final ObjectOutput objectOutput = mock(ObjectOutput.class);
+    doThrow(IOException.class).when(objectOutput).close();
+
+    Closeables.close(objectOutput);
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/LoggingEventMatchers.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/LoggingEventMatchers.java
@@ -1,0 +1,47 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.hamcrest.Matcher;
+
+import static org.junit.matchers.JUnitMatchers.containsString;
+
+/**
+ * Matchers for working with {@link ILoggingEvent}s.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public final class LoggingEventMatchers {
+
+  /**
+   * Matches an {@link ILoggingEvent} which has a {@code message} which contains the given {@code message}.
+   *
+   * @param message the message which is expected to be contained in the event's message
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<ILoggingEvent> containsMessage(final String message) {
+    return new LoggingEventMessageMatcher(containsString(message));
+  }
+
+  /**
+   * Matches an {@link ILoggingEvent} which has a {@code message} which matches the given {@code matcher}.
+   *
+   * @param matcher the matcher for the {@code message}
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<ILoggingEvent> containsMessage(final Matcher<String> matcher) {
+    return new LoggingEventMessageMatcher(matcher);
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/LoggingEventMessageMatcher.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/LoggingEventMessageMatcher.java
@@ -1,0 +1,43 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.internal.matchers.TypeSafeMatcher;
+
+/**
+ * A matcher which expects the {@link ILoggingEvent}'s {@code message} to match a given {@link Matcher}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class LoggingEventMessageMatcher extends TypeSafeMatcher<ILoggingEvent> {
+
+  private Matcher<String> matcher;
+
+  public LoggingEventMessageMatcher(final Matcher<String> matcher) {
+    this.matcher = matcher;
+  }
+
+  @Override
+  public boolean matchesSafely(final ILoggingEvent event) {
+    return matcher.matches(event.getMessage());
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    matcher.describeTo(description);
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/StatusLevelMatcher.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/StatusLevelMatcher.java
@@ -1,0 +1,50 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.core.status.Status;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * A matcher which expects the {@link Status}' {@code level} to match a given {@code level}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class StatusLevelMatcher extends TypeSafeMatcher<Status> {
+
+  private final int level;
+
+  public StatusLevelMatcher(int level) {
+    this.level = level;
+  }
+
+  @Override
+  public boolean matchesSafely(final Status status) {
+    return level == status.getLevel();
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    final String levelString;
+    switch(level) {
+      case Status.INFO: levelString = "INFO"; break;
+      case Status.WARN: levelString = "WARN"; break;
+      case Status.ERROR:  levelString = "ERROR"; break;
+      default: throw new IllegalStateException("Unexpected level: " + level);
+    }
+
+    description.appendText("level to be " + levelString);
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/StatusMatchers.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/StatusMatchers.java
@@ -1,0 +1,70 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.core.status.Status;
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.internal.matchers.IsCollectionContaining.hasItem;
+import static org.junit.matchers.JUnitMatchers.containsString;
+
+/**
+ * Matchers for working with {@link Status}es.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class StatusMatchers {
+
+  /**
+   * Matches an iterable of {@link Status}es which has no item with a {@code message} containing the given {@code message}.
+   *
+   * @param message the message to not be contained in the items of the iterable
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<Iterable<Status>> hasNoItemWhichContainsMessage(final String message) {
+    return not(hasItem(containsMessage(message)));
+  }
+
+  /**
+   * Matches a {@link Status} which has a {@code message} containing the given {@code message}.
+   *
+   * @param message the expected message
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<Status> containsMessage(final String message) {
+    return new StatusMessageMatcher(containsString(message));
+  }
+
+  /**
+   * Matches a {@link Status} which has a {@code level} matching the given {@code level}.
+   *
+   * @param level the expected level
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<Status> hasLevel(final int level) {
+    return new StatusLevelMatcher(level);
+  }
+
+  /**
+   * Matches a {@link Status} which has a {@code throwable} which is an instance of the provided {@code throwableClass}.
+   *
+   * @param throwableClass the expected throwable class
+   * @return a new {@link Matcher} instance
+   */
+  public static Matcher<Status> hasThrowable(final Class<? extends Throwable> throwableClass) {
+    return new StatusThrowableMatcher(instanceOf(throwableClass));
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/StatusMessageMatcher.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/StatusMessageMatcher.java
@@ -1,0 +1,43 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.core.status.Status;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.internal.matchers.TypeSafeMatcher;
+
+/**
+ * Matcher which expects the {@link Status}' {@code message} to match a given {@link Matcher}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class StatusMessageMatcher extends TypeSafeMatcher<Status> {
+
+  private Matcher<String> matcher;
+
+  public StatusMessageMatcher(final Matcher<String> matcher) {
+    this.matcher = matcher;
+  }
+
+  @Override
+  public boolean matchesSafely(final Status status) {
+    return matcher.matches(status.getMessage());
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    matcher.describeTo(description);
+  }
+}

--- a/logback-classic/src/test/java/ch/qos/logback/matchers/StatusThrowableMatcher.java
+++ b/logback-classic/src/test/java/ch/qos/logback/matchers/StatusThrowableMatcher.java
@@ -1,0 +1,43 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.matchers;
+
+import ch.qos.logback.core.status.Status;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher which expects the {@link Status}' {@code throwable} to match a given {@link Matcher}.
+ *
+ * @author Sebastian Gr&ouml;bler
+ */
+public class StatusThrowableMatcher extends TypeSafeMatcher<Status> {
+
+  private Matcher<Object> matcher;
+
+  public StatusThrowableMatcher(final Matcher<Object> matcher) {
+    this.matcher = matcher;
+  }
+
+  @Override
+  public boolean matchesSafely(final Status status) {
+    return matcher.matches(status.getThrowable());
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    matcher.describeTo(description);
+  }
+}

--- a/logback-core/src/test/java/ch/qos/logback/core/net/SocketAppenderBaseTest.java
+++ b/logback-core/src/test/java/ch/qos/logback/core/net/SocketAppenderBaseTest.java
@@ -1,0 +1,133 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2013, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.core.net;
+
+import ch.qos.logback.core.spi.PreSerializationTransformer;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Sebastian Gr&ouml;bler
+ */
+public class SocketAppenderBaseTest {
+
+  private final SocketAppenderBase socketAppenderBase = mock(SocketAppenderBase.class);
+
+  @Before
+  public void beforeEachTest() throws IOException {
+    // setup default state and behaviour
+    socketAppenderBase.setRemoteHost("localhost");
+    socketAppenderBase.oos = MockObjectOutputStream.createNopMock();
+    when(socketAppenderBase.getPST()).thenReturn(mock(PreSerializationTransformer.class));
+
+    // make sure real methods are called on the abstract class
+    doCallRealMethod().when(socketAppenderBase).tryAppend(anyObject());
+    doCallRealMethod().when(socketAppenderBase).fireConnector();
+    doCallRealMethod().when(socketAppenderBase).isConnecting();
+  }
+
+  @Test
+  public void isConnectingReturnsTrueWhenThereIsAConnectorThreadRunning() {
+    socketAppenderBase.fireConnector();
+    assertTrue(socketAppenderBase.isConnecting());
+  }
+
+  @Test
+  public void isConnectingReturnsFalseWhenThereIsNoConnectorThreadRunning() {
+    assertFalse(socketAppenderBase.isConnecting());
+  }
+
+  @Test
+  public void tryAppendReturnsTrueOnSuccessfulAppend() {
+    assertTrue(socketAppenderBase.tryAppend(mock(Object.class)));
+  }
+
+  @Test
+  public void tryAppendReturnsFalseOnNullEvent() {
+    assertFalse(socketAppenderBase.tryAppend(null));
+  }
+
+  @Test
+  public void tryAppendReturnsFalseOnMissingAddress() {
+    socketAppenderBase.address = null;
+    assertFalse(socketAppenderBase.tryAppend(mock(Object.class)));
+  }
+
+  @Test
+  public void tryAppendReturnsFalseWhenThereIsNoConnection() {
+    socketAppenderBase.oos = null;
+    assertFalse(socketAppenderBase.tryAppend(mock(Object.class)));
+  }
+
+  @Test
+  public void tryAppendReturnsFalseWhenThereIsAnIOException() {
+    socketAppenderBase.oos = MockObjectOutputStream.createIOExceptionThrowingMock();
+    assertFalse(socketAppenderBase.tryAppend(mock(Object.class)));
+  }
+
+  /**
+   * Allows mocking of {@link ObjectOutputStream#writeObject(Object)} by
+   * redirecting to {@link ObjectOutputStream#writeObjectOverride(Object)}.
+   */
+  public static class MockObjectOutputStream extends ObjectOutputStream {
+
+    public static ObjectOutputStream createNopMock() {
+      return createMock(false);
+    }
+
+    public static ObjectOutputStream createIOExceptionThrowingMock() {
+      return createMock(true);
+    }
+
+    private static ObjectOutputStream createMock(final boolean throwIOException) {
+      try {
+        return new MockObjectOutputStream(throwIOException);
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private final boolean throwIOException;
+
+    protected MockObjectOutputStream(boolean throwIOException) throws IOException {
+      super();
+      this.throwIOException = throwIOException;
+    }
+
+    @Override
+    protected void writeObjectOverride(final Object obj) throws IOException {
+      if (throwIOException) {
+        throw new IOException();
+      }
+    }
+
+    @Override
+    public void flush() throws IOException {
+      // NOP
+    }
+
+    @Override
+    public void close() throws IOException {
+      // NOP
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,18 @@
         </exclusions>
       </dependency>
 
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>15.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>2.3</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The `FileBufferingSocketAppender` and it's auxiliary classes provide the following features in addition to a regular SocketAppender:
- events are buffered (serialized) to disk
- events are send in batches
- events are send in intervals
- events are persistent, even when there is currently no socket connection or there is an error during transmission
  - events will be evicted from disk in a FIFO mode, defined through a file count quota (amount of log events) 

The new appender takes the following configuration:
- logFolder (required)
- fileExtension (default: .ser)
- batchSize (default: 50)
- readInterval (default: 1min)
- fileCountQuota (default: 500)

Furthermore it provides the same configuration interfaces as the `SocketAppender`. Internally it holds an instance of the `SocketAppender` of which it manages the state and to which it delegates the previously mentioned configuration interface calls.

Discussion/Questions:
1. why is there no SSLSocketAppender in the logback-android fork?
2. what would be the best "logback way" to make the current implementation not use a composition but an aggregation instead? so that the `SocketAppender` would not be instantiated by the `FileBufferingSocketAppender`but through the regular logback mechanisms.
3. why is there a configuration check (address != null) in the SocketAppenderBase.append (now tryAppend) method?
4. What would be the best way to do a full-integration test of the new appender?
5. Though the new appender is mostly useful in context of remote logging with android it might also makes sense to push it all the way upstream to the logback origin and rebase the logback-android project to it. What do you think?
