### PR TITLE
FileAppender should not attempt to make absolute an already absolute file path

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -267,7 +267,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
 
   /**
    * Gets the absolute path to the filename, starting from the app's
-   * "files" directory
+   * "files" directory, if it is not already an absolute path
    *
    * @param filename filename to evaluate
    * @return absolute path to the filename
@@ -276,7 +276,11 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
     // In Android, relative paths created with File() are relative
     // to root, so fix it by prefixing the path to the app's "files"
     // directory.
-    if (EnvUtil.isAndroidOS()) {
+    // This transformation is rather expensive, since it involves loading the
+    // Android manifest from the APK (which is a ZIP file), and parsing it to
+    // retrieve the application package name. This should be avoided if
+    // possible as it may perceptibly delay the app launch time.
+    if (EnvUtil.isAndroidOS() && !new File(filename).isAbsolute()) {
       String dataDir = context.getProperty(CoreConstants.DATA_DIR_KEY);
       filename = FileUtil.prefixRelativePath(dataDir, filename);
     }


### PR DESCRIPTION
This transformation is rather expensive, since it involves loading the Android manifest from the APK (which is a ZIP file), and parsing it to retrieve the application package name. This should be avoided if possible as it may perceptibly delay the app launch time.
