### PR TITLE
Allow rolling backup on android

### DIFF
--- a/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -104,7 +104,6 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
     String file = getFile();
 
     if (file != null) {
-      file = getAbsoluteFilePath(file);
       addInfo("File property is set to [" + file + "]");
 
       if (prudent) {
@@ -156,9 +155,8 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
    */
   protected boolean openFile(String filename) throws IOException {
     boolean successful = false;
-    filename = getAbsoluteFilePath(filename);
     synchronized (lock) {
-      File file = new File(filename);
+      File file = FileUtil.createFile(getContext(), filename);
       if (FileUtil.isParentDirectoryCreationRequired(file)) {
         boolean result = FileUtil.createMissingParentDirectories(file);
         if (!result) {
@@ -263,27 +261,5 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
     }
 
     super.subAppend(event);
-  }
-
-  /**
-   * Gets the absolute path to the filename, starting from the app's
-   * "files" directory, if it is not already an absolute path
-   *
-   * @param filename filename to evaluate
-   * @return absolute path to the filename
-   */
-  private String getAbsoluteFilePath(String filename) {
-    // In Android, relative paths created with File() are relative
-    // to root, so fix it by prefixing the path to the app's "files"
-    // directory.
-    // This transformation is rather expensive, since it involves loading the
-    // Android manifest from the APK (which is a ZIP file), and parsing it to
-    // retrieve the application package name. This should be avoided if
-    // possible as it may perceptibly delay the app launch time.
-    if (EnvUtil.isAndroidOS() && !new File(filename).isAbsolute()) {
-      String dataDir = context.getProperty(CoreConstants.DATA_DIR_KEY);
-      filename = FileUtil.prefixRelativePath(dataDir, filename);
-    }
-    return filename;
   }
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/FixedWindowRollingPolicy.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/FixedWindowRollingPolicy.java
@@ -18,6 +18,7 @@ import java.util.Date;
 
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.rolling.helper.*;
+import ch.qos.logback.core.util.FileUtil;
 
 /**
  * When rolling over, <code>FixedWindowRollingPolicy</code> renames files
@@ -126,7 +127,7 @@ public class FixedWindowRollingPolicy extends RollingPolicyBase {
     // If maxIndex <= 0, then there is no file renaming to be done.
     if (maxIndex >= 0) {
       // Delete the oldest file, to keep Windows happy.
-      File file = new File(fileNamePattern.convertInt(maxIndex));
+      File file = FileUtil.createFile(getContext(), fileNamePattern.convertInt(maxIndex));
 
       if (file.exists()) {
         file.delete();
@@ -135,7 +136,7 @@ public class FixedWindowRollingPolicy extends RollingPolicyBase {
       // Map {(maxIndex - 1), ..., minIndex} to {maxIndex, ..., minIndex+1}
       for (int i = maxIndex - 1; i >= minIndex; i--) {
         String toRenameStr = fileNamePattern.convertInt(i);
-        File toRename = new File(toRenameStr);
+        File toRename = FileUtil.createFile(context, toRenameStr);
         // no point in trying to rename an inexistent file
         if (toRename.exists()) {
           util.rename(toRenameStr, fileNamePattern.convertInt(i + 1));
@@ -147,8 +148,9 @@ public class FixedWindowRollingPolicy extends RollingPolicyBase {
       // move active file name to min
       switch (compressionMode) {
       case NONE:
-        util.rename(getActiveFileName(), fileNamePattern
-            .convertInt(minIndex));
+        String src = getActiveFileName();
+        String target = fileNamePattern.convertInt(minIndex);
+        util.rename(src, target);
         break;
       case GZ:
         compressor.compress(getActiveFileName(), fileNamePattern.convertInt(minIndex), null);

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/RollingFileAppender.java
@@ -16,6 +16,7 @@ package ch.qos.logback.core.rolling;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.rolling.helper.CompressionMode;
 import ch.qos.logback.core.rolling.helper.FileNamePattern;
+import ch.qos.logback.core.util.FileUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,7 +82,7 @@ public class RollingFileAppender<E> extends FileAppender<E> {
       }
     }
 
-    currentlyActiveFile = new File(getFile());
+    currentlyActiveFile = FileUtil.createFile(getContext(), getFile());
     addInfo("Active log file name: " + getFile());
     super.start();
   }
@@ -146,7 +147,7 @@ public class RollingFileAppender<E> extends FileAppender<E> {
       try {
         // update the currentlyActiveFile
         // http://jira.qos.ch/browse/LBCORE-90
-        currentlyActiveFile = new File(filename);
+        currentlyActiveFile = FileUtil.createFile(getContext(), filename);
 
         // This will also close the file. This is OK since multiple
         // close operations are safe.

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/SizeAndTimeBasedFNATP.java
@@ -22,6 +22,7 @@ import ch.qos.logback.core.rolling.helper.CompressionMode;
 import ch.qos.logback.core.rolling.helper.FileFilterUtil;
 import ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemover;
 import ch.qos.logback.core.util.FileSize;
+import ch.qos.logback.core.util.FileUtil;
 
 @NoAutoStart
 public class SizeAndTimeBasedFNATP<E> extends
@@ -57,7 +58,7 @@ public class SizeAndTimeBasedFNATP<E> extends
   }
 
   void computeCurrentPeriodsHighestCounterValue(final String stemRegex) {
-    File file = new File(getCurrentPeriodsFileNameWithoutCompressionSuffix());
+    File file = FileUtil.createFile(getContext(), getCurrentPeriodsFileNameWithoutCompressionSuffix());
     File parentDir = file.getParentFile();
 
     File[] matchingFileArray = FileFilterUtil

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
@@ -20,6 +20,7 @@ import ch.qos.logback.core.rolling.helper.ArchiveRemover;
 import ch.qos.logback.core.rolling.helper.DateTokenConverter;
 import ch.qos.logback.core.rolling.helper.RollingCalendar;
 import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.util.FileUtil;
 
 abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends
         ContextAwareBase implements TimeBasedFileNamingAndTriggeringPolicy<E> {
@@ -57,7 +58,7 @@ abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends
 
     setDateInCurrentPeriod(new Date(getCurrentTime()));
     if (tbrp.getParentsRawFileProperty() != null) {
-      File currentFile = new File(tbrp.getParentsRawFileProperty());
+      File currentFile = FileUtil.createFile(getContext(), tbrp.getParentsRawFileProperty());
       if (currentFile.exists() && currentFile.canRead()) {
         setDateInCurrentPeriod(new Date(currentFile.lastModified()));
       }

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -64,6 +64,7 @@ public class Compressor extends ContextAwareBase {
   }
 
   private void zipCompress(String nameOfFile2zip, String nameOfZippedFile, String innerEntryName) {
+    nameOfFile2zip = FileUtil.getAbsoluteFilePath(getContext(), nameOfFile2zip);
     File file2zip = new File(nameOfFile2zip);
 
     if (!file2zip.exists()) {
@@ -82,6 +83,7 @@ public class Compressor extends ContextAwareBase {
       nameOfZippedFile = nameOfZippedFile + ".zip";
     }
 
+    nameOfZippedFile = FileUtil.getAbsoluteFilePath(getContext(), nameOfZippedFile);
     File zippedFile = new File(nameOfZippedFile);
 
     if (zippedFile.exists()) {
@@ -168,6 +170,7 @@ public class Compressor extends ContextAwareBase {
 
 
   private void gzCompress(String nameOfFile2gz, String nameOfgzedFile) {
+    nameOfFile2gz = FileUtil.getAbsoluteFilePath(getContext(), nameOfFile2gz);
     File file2gz = new File(nameOfFile2gz);
 
     if (!file2gz.exists()) {
@@ -182,6 +185,7 @@ public class Compressor extends ContextAwareBase {
       nameOfgzedFile = nameOfgzedFile + ".gz";
     }
 
+    nameOfgzedFile = FileUtil.getAbsoluteFilePath(getContext(), nameOfgzedFile);
     File gzedFile = new File(nameOfgzedFile);
 
     if (gzedFile.exists()) {

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RenameUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/RenameUtil.java
@@ -52,10 +52,10 @@ public class RenameUtil extends ContextAwareBase {
       addWarn("Source and target files are the same [" + src + "]. Skipping.");
       return;
     }
-    File srcFile = new File(src);
+    File srcFile = FileUtil.createFile(getContext(), src);
 
     if (srcFile.exists()) {
-      File targetFile = new File(target);
+      File targetFile = FileUtil.createFile(getContext(), target);
       createMissingTargetDirsIfNecessary(targetFile);
 
       addInfo("Renaming file [" + srcFile + "] to [" + targetFile + "]");

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/SizeAndTimeBasedArchiveRemover.java
@@ -13,6 +13,8 @@
  */
 package ch.qos.logback.core.rolling.helper;
 
+import ch.qos.logback.core.util.FileUtil;
+
 import java.io.File;
 import java.util.Date;
 
@@ -28,8 +30,8 @@ public class SizeAndTimeBasedArchiveRemover extends DefaultArchiveRemover {
 
     String regex = fileNamePattern.toRegexForFixedDate(dateOfPeriodToClean);
     String stemRegex = FileFilterUtil.afterLastSlash(regex);
-    File archive0 = new File(fileNamePattern.convertMultipleArguments(
-        dateOfPeriodToClean, 0));
+    File archive0 = FileUtil.createFile(getContext(), fileNamePattern.convertMultipleArguments(
+            dateOfPeriodToClean, 0));
     // in case the file has no directory part, i.e. if it's written into the
     // user's current directory.
     archive0 = archive0.getAbsoluteFile();

--- a/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import ch.qos.logback.core.pattern.Converter;
 import ch.qos.logback.core.pattern.LiteralConverter;
 import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.util.FileUtil;
 
 public class TimeBasedArchiveRemover extends DefaultArchiveRemover {
 
@@ -30,7 +31,7 @@ public class TimeBasedArchiveRemover extends DefaultArchiveRemover {
   protected void cleanByPeriodOffset(Date now, int periodOffset) {
     Date date2delete = rc.getRelativeDate(now, periodOffset);
     String filename = fileNamePattern.convert(date2delete);
-    File file2Delete = new File(filename);
+    File file2Delete = FileUtil.createFile(getContext(), filename);
     if (file2Delete.exists() && file2Delete.isFile()) {
       file2Delete.delete();
       addInfo("deleting " + file2Delete);

--- a/logback-core/src/main/java/ch/qos/logback/core/util/EnvUtil.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/EnvUtil.java
@@ -21,17 +21,23 @@ import java.util.List;
  */
 public class EnvUtil {
 
+  // cache Android environment identifier; cannot change during the runtime
+  private static Boolean isAndroid = null;
+
   /**
    * Heuristically determines whether the current OS is Android
    */
   static public boolean isAndroidOS() {
-    String osname = OptionHelper.getSystemProperty("os.name");
-    String root = OptionHelper.getEnv("ANDROID_ROOT");
-    String data = OptionHelper.getEnv("ANDROID_DATA");
+    if (isAndroid == null) {
+      String osname = OptionHelper.getSystemProperty("os.name");
+      String root = OptionHelper.getEnv("ANDROID_ROOT");
+      String data = OptionHelper.getEnv("ANDROID_DATA");
 
-    return osname != null && osname.contains("Linux") &&
-        root != null && root.contains("/system") &&
-        data != null && data.contains("/data");
+      isAndroid = osname != null && osname.contains("Linux") &&
+          root != null && root.contains("/system") &&
+          data != null && data.contains("/data");
+    }
+    return isAndroid;
   }
 
   static private boolean isJDK_N_OrHigher(int n) {


### PR DESCRIPTION
Rolling logs backup doesn't work on Android. This PR fixes it. It switches in all relevant places from plan relative `new File(...)` (doesn't work on Android because root is actually in `data/<packageName>/files`) to absolute file paths.