### PR TITLE
Fix logger initialization error in unit tests

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -94,8 +94,8 @@ public class AndroidContextUtil {
   public String getMountedExternalStorageDirectoryPath() {
     String path = null;
     String state = Environment.getExternalStorageState();
-    if (state.equals(Environment.MEDIA_MOUNTED) ||
-        state.equals(Environment.MEDIA_MOUNTED_READ_ONLY)) {
+    if (Environment.MEDIA_MOUNTED.equals(state) ||
+        Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
       path = absPath(Environment.getExternalStorageDirectory());
     }
     return path;


### PR DESCRIPTION
Environment.getExternalStorageState() returns null in Unit Tests. Which causes and error in the logger initialization. This pull request fixes the issue.
<img width="783" alt="Screen Shot 2019-09-17 at 13 25 05" src="https://user-images.githubusercontent.com/5956780/65034751-4f25d000-d950-11e9-8f10-8bc9015ca7df.png">
