### PR TITLE
Use of EXT_DIR with Android API 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ android:
     - platform-tools
 
     # The BuildTools version used by the project
+    - build-tools-28.0.3
     - build-tools-29.0.2
 
     # The SDK version used to compile the project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: android
 android:
   components:
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-29.0.2
+    - android-29
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: android
 android:
   components:
+    # Use the latest revision of Android SDK Tools
+    - tools
+    - platform-tools
+
+    # The BuildTools version used by the project
     - build-tools-29.0.2
+
+    # The SDK version used to compile the project
     - android-29
 
 sudo: false

--- a/logback-android/build.gradle
+++ b/logback-android/build.gradle
@@ -7,7 +7,7 @@ apply from: "${rootProject.projectDir}/gradle/docs.gradle"
 apply from: "${rootProject.projectDir}/gradle/deploy.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_5
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode VERSION_CODE.toInteger()
         versionName VERSION_NAME
     }
@@ -52,7 +52,7 @@ dependencies {
     }
 
     testImplementation 'org.hamcrest:hamcrest-junit:2.0.0.0'
-    testImplementation 'org.robolectric:robolectric:4.0.2'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation 'joda-time:joda-time:2.10.1'
 

--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -96,7 +96,7 @@ public class AndroidContextUtil {
     String state = Environment.getExternalStorageState();
     if (state.equals(Environment.MEDIA_MOUNTED) ||
         state.equals(Environment.MEDIA_MOUNTED_READ_ONLY)) {
-      path = this.context != null ? this.context.getExternalFilesDir(null).getAbsolutePath() :  null;
+      path = getExternalStorageDirectoryPath();
     }
     return path;
   }
@@ -104,14 +104,33 @@ public class AndroidContextUtil {
   /**
    * Gets the path to the external storage directory
    *
+   * This API is available on SDK 8+. On API versions 29 onwards,
+   * this function uses the implementation in
+   * {@link android.content.Context#getExternalFilesDir(java.lang.String)}
+   * which is the proposed replacement for
+   * {@link android.os.Environment#getExternalStorageDirectory()}.
+   *
    * @return the absolute path to the external storage directory
    */
+  @TargetApi(8)
+  @SuppressWarnings("deprecation")
   public String getExternalStorageDirectoryPath() {
-    return this.context != null
-            ? this.context.getExternalFilesDir(null).getAbsolutePath()
-            : null;
+    if (Build.VERSION.SDK_INT >= 29) {
+      return getExternalFilesDirectoryPath();
+    } else {
+      return Environment.getExternalStorageDirectory().getAbsolutePath();
+    }
   }
 
+  /**
+   * Gets the path to the external storage directory
+   *
+   * This API is available on SDK 8+. This function uses the implementation in
+   * {@link android.content.Context#getExternalFilesDir(java.lang.String)}.
+   *
+   * @return the absolute path to the external storage directory
+   */
+  @TargetApi(8)
   public String getExternalFilesDirectoryPath() {
     return this.context != null
             ? absPath(this.context.getExternalFilesDir(null))

--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -67,7 +67,7 @@ public class AndroidContextUtil {
     context.putProperties(props);
   }
 
-  private static ContextWrapper getContext() {
+  protected static ContextWrapper getContext() {
     try {
       Class<?> c = Class.forName("android.app.AppGlobals");
       Method method = c.getDeclaredMethod("getInitialApplication");
@@ -96,7 +96,7 @@ public class AndroidContextUtil {
     String state = Environment.getExternalStorageState();
     if (state.equals(Environment.MEDIA_MOUNTED) ||
         state.equals(Environment.MEDIA_MOUNTED_READ_ONLY)) {
-      path = absPath(Environment.getExternalStorageDirectory());
+      path = this.context != null ? this.context.getExternalFilesDir(null).getAbsolutePath() :  null;
     }
     return path;
   }
@@ -107,7 +107,9 @@ public class AndroidContextUtil {
    * @return the absolute path to the external storage directory
    */
   public String getExternalStorageDirectoryPath() {
-    return Environment.getExternalStorageDirectory().getAbsolutePath();
+    return this.context != null
+            ? this.context.getExternalFilesDir(null).getAbsolutePath()
+            : null;
   }
 
   public String getExternalFilesDirectoryPath() {

--- a/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
@@ -50,14 +50,14 @@ public class AndroidContextUtilTest {
   public void getMountedExternalStorageDirectoryPathReturnsPathWhenMounted() {
     ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
     assertThat(contextUtil.getMountedExternalStorageDirectoryPath(),
-               is(Environment.getExternalStorageDirectory().getAbsolutePath()));
+            is(contextUtil.getContext().getExternalFilesDir(null).getAbsolutePath()));
   }
 
   @Test
   public void getMountedExternalStorageDirectoryPathReturnsPathWhenMountedReadOnly() {
     ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED_READ_ONLY);
     assertThat(contextUtil.getMountedExternalStorageDirectoryPath(),
-            is(Environment.getExternalStorageDirectory().getAbsolutePath()));
+            is(contextUtil.getContext().getExternalFilesDir(null).getAbsolutePath()));
   }
 
   @Test
@@ -111,7 +111,7 @@ public class AndroidContextUtilTest {
   @Test
   public void getExternalStorageDirectoryPathIsNotEmpty() {
     assertThat(contextUtil.getExternalStorageDirectoryPath(),
-            is(Environment.getExternalStorageDirectory().getAbsolutePath()));
+            is(contextUtil.getContext().getExternalFilesDir(null).getAbsolutePath()));
   }
 
   @Test


### PR DESCRIPTION
When resolving the "EXT_DIR" variable the method Environment.getExternalStorageDirectory() is used.
As of Android API 29 this method is useless and deprecated (see the [docs](https://developer.android.com/reference/android/os/Environment.html#getExternalStorageDirectory()) for details). 

This patch replaces the usages of "getExternalStorageDirectory" with the proposed alternative [Context.getExternalFilesDir()](https://developer.android.com/reference/android/content/Context.html#getExternalFilesDir(java.lang.String))