### PR TITLE
Cascade delete logging_event_exception and logging_event_property

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/classic/db/SQLBuilder.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/db/SQLBuilder.java
@@ -99,7 +99,7 @@ public class SQLBuilder {
         .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(") ")
         .append("REFERENCES ")
         .append(dbNameResolver.getTableName(TableName.LOGGING_EVENT)).append(" (")
-        .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(") ")
+        .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(")  ON DELETE CASCADE ")
         .append(")");
     return sqlBuilder.toString();
   }
@@ -117,7 +117,7 @@ public class SQLBuilder {
         .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(") ")
         .append("REFERENCES ")
         .append(dbNameResolver.getTableName(TableName.LOGGING_EVENT)).append(" (")
-        .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(") ")
+        .append(dbNameResolver.getColumnName(ColumnName.EVENT_ID)).append(")  ON DELETE CASCADE ")
         .append(")");
     return sqlBuilder.toString();
   }


### PR DESCRIPTION
SQLiteBuilder.buildDeleteExpiredLogsSQL() only deletes logging_event entries. Added cascade delete to logging_event_exception and logging_event_property to also delete related entries.