### PR TITLE
Dont set GMT+0 timezone in RollingCalendar if no timezone is given (fixes #213)

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/RollingCalendar.java
@@ -72,7 +72,9 @@ public class RollingCalendar extends GregorianCalendar {
   }
 
   public RollingCalendar(String datePattern) {
-    this(datePattern, GMT_TIMEZONE, Locale.US);
+    super();
+    this.datePattern = datePattern;
+    this.periodicityType = computePeriodicityType();
   }
 
   public RollingCalendar(String datePattern, TimeZone tz, Locale locale) {

--- a/logback-android/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/rolling/helper/RollingCalendarTest.java
@@ -90,7 +90,7 @@ public class RollingCalendarTest {
   }
 
   private Calendar getEndOfNextNthPeriod(String dateFormat, Date date, int n) {
-    RollingCalendar rc = new RollingCalendar(dateFormat);
+    RollingCalendar rc = new RollingCalendar(dateFormat, GMT_TIMEZONE, Locale.US);
     Date nextDate = rc.getEndOfNextNthPeriod(date, n);
     Calendar cal = Calendar.getInstance(GMT_TIMEZONE, Locale.US);
     cal.setTime(nextDate);


### PR DESCRIPTION
Setting the timezone to GMT(+0) if no timezone is given, leads to daily rollover at midnight GMT+0 instead of midnight of the systems timezone.
Calling the default super contructor of GregorianCalendar instead of the one with a TimeZone parameter uses the systems default timezone and locale.
This fixes https://github.com/tony19/logback-android/issues/213 and reverts commit https://github.com/tony19/logback-android/commit/446eb7ca7ba07f97712d79afbddd89bed8030c6c
