### PR TITLE
feat: enable hostnameVerification flag in SSL sockets

### DIFF
--- a/logback-android/build.gradle
+++ b/logback-android/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     testImplementation(group: 'org.subethamail', name: 'subethasmtp', version: '3.1.7') {
         exclude(module: 'slf4j-api')
     }
+    testImplementation project(path: ':logback-android')
 
     compileOnly "org.slf4j:slf4j-api:${slf4jVersion}"
 

--- a/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
@@ -193,6 +193,9 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
           ObjectWriter objectWriter = createObjectWriterForSocket();
           addInfo(peerId + "connection established");
           dispatchEvents(objectWriter);
+        } catch (javax.net.ssl.SSLHandshakeException she) {
+          // FIXME
+          Thread.sleep(DEFAULT_RECONNECTION_DELAY);
         } catch (IOException ex) {
           addInfo(peerId + "connection failed: " + ex);
         } finally {

--- a/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurable.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurable.java
@@ -23,6 +23,7 @@ package ch.qos.logback.core.net.ssl;
  * to facilitate unit testing.
  *
  * @author Carl Harris
+ * @author Bruno Harbulot
  */
 public interface SSLConfigurable {
 
@@ -84,4 +85,5 @@ public interface SSLConfigurable {
    */
   void setWantClientAuth(boolean state);
 
+  void setHostnameVerification(boolean verifyHostname);
 }

--- a/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableServerSocket.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableServerSocket.java
@@ -15,6 +15,9 @@
  */
 package ch.qos.logback.core.net.ssl;
 
+import android.annotation.TargetApi;
+
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 
 /**
@@ -62,4 +65,14 @@ public class SSLConfigurableServerSocket implements SSLConfigurable {
     delegate.setWantClientAuth(state);
   }
 
+  @TargetApi(24)
+  @Override
+  public void setHostnameVerification(boolean hostnameVerification) {
+    if (!hostnameVerification) {
+      return;
+    }
+    SSLParameters sslParameters = delegate.getSSLParameters();
+    sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+    delegate.setSSLParameters(sslParameters);
+  }
 }

--- a/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableSocket.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLConfigurableSocket.java
@@ -15,12 +15,16 @@
  */
 package ch.qos.logback.core.net.ssl;
 
+import android.annotation.TargetApi;
+
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 
 /**
  * An {@link SSLConfigurable} wrapper for an {@link SSLSocket}.
  *
  * @author Carl Harris
+ * @author Bruno Harbulot
  */
 public class SSLConfigurableSocket implements SSLConfigurable {
 
@@ -62,4 +66,14 @@ public class SSLConfigurableSocket implements SSLConfigurable {
     delegate.setWantClientAuth(state);
   }
 
+  @TargetApi(24)
+  @Override
+  public void setHostnameVerification(boolean hostnameVerification) {
+    if (!hostnameVerification) {
+      return;
+    }
+    SSLParameters sslParameters = delegate.getSSLParameters();
+    sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+    delegate.setSSLParameters(sslParameters);
+  }
 }

--- a/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/ssl/SSLParametersConfiguration.java
@@ -41,6 +41,7 @@ public class SSLParametersConfiguration extends ContextAwareBase {
   private Boolean wantClientAuth;
   private String[] enabledProtocols;
   private String[] enabledCipherSuites;
+  private Boolean hostnameVerification;
 
   /**
    * Configures SSL parameters on an {@link SSLConfigurable}.
@@ -57,6 +58,20 @@ public class SSLParametersConfiguration extends ContextAwareBase {
     if (isWantClientAuth() != null) {
       socket.setWantClientAuth(isWantClientAuth());
     }
+    if (hostnameVerification != null) {
+      addInfo("hostnameVerification="+hostnameVerification);
+      socket.setHostnameVerification(hostnameVerification);
+    }
+  }
+
+  public boolean getHostnameVerification() {
+    if(hostnameVerification == null)
+      return false;
+    return hostnameVerification;
+  }
+
+  public void setHostnameVerification(boolean hostnameVerification) {
+    this.hostnameVerification = hostnameVerification;
   }
 
   /**

--- a/logback-android/src/test/java/ch/qos/logback/core/net/DefaultSocketConnectorTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/net/DefaultSocketConnectorTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import ch.qos.logback.core.net.SocketConnector.ExceptionHandler;
@@ -47,10 +46,9 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Carl Harris
  */
-@Ignore
 public class DefaultSocketConnectorTest {
 
-  private static final int DELAY = 1000;
+  private static final int DELAY = 2000;
   private static final int SHORT_DELAY = 10;
   private static final int RETRY_DELAY = 10;
 

--- a/logback-android/src/test/java/ch/qos/logback/core/net/ssl/mock/MockSSLConfigurable.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/net/ssl/mock/MockSSLConfigurable.java
@@ -94,4 +94,7 @@ public class MockSSLConfigurable implements SSLConfigurable {
     this.wantClientAuth = wantClientAuth;
   }
 
+  @Override
+  public void setHostnameVerification(boolean verifyHostname) {
+  }
 }


### PR DESCRIPTION
ported from logback

https://github.com/qos-ch/logback/commit/9b67089750e64cd9f8091a1e9d315fdb527221df

fix #250
