### PR TITLE
fix: compatible with windows path in Robolectric test.

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/FileFinder.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/FileFinder.java
@@ -27,6 +27,7 @@ class FileFinder {
 
   private static final String REGEX_MARKER_START = "(?:\uFFFE)?";
   private static final String REGEX_MARKER_END = "(?:\uFFFF)?";
+  private static final String PATTERN_SEPARATOR = "/";  // separator with slashified path and pattern
   private FileProvider fileProvider;
 
   FileFinder(FileProvider fileProvider) {
@@ -93,10 +94,10 @@ class FileFinder {
     }
   }
 
-  List<PathPart> splitPath(String pattern) {
+  List<PathPart> splitPath(String pathPattern) {
     List<PathPart> parts = new ArrayList<PathPart>();
     List<String> literals = new ArrayList<String>();
-    for (String p : pattern.split(File.separator)) {
+    for (String p : pathPattern.split(PATTERN_SEPARATOR)) {
       final boolean isRegex = p.contains(REGEX_MARKER_START) && p.contains(REGEX_MARKER_END);
       p = p.replace(REGEX_MARKER_START, "").replace(REGEX_MARKER_END, "");
       if (isRegex) {
@@ -115,17 +116,17 @@ class FileFinder {
     return parts;
   }
 
-  static String regexEscapePath(String path) {
-    if (path.contains(File.separator)) {
-      String[] parts = path.split(File.separator);
+  static String regexEscapePath(String pattern) {
+    if (pattern.contains(PATTERN_SEPARATOR)) {
+      String[] parts = pattern.split(PATTERN_SEPARATOR);
       for (int i = 0; i < parts.length; i++) {
         if (parts[i].length() > 0) {
           parts[i] = REGEX_MARKER_START + parts[i] + REGEX_MARKER_END;
         }
       }
-      return TextUtils.join(File.separator, parts);
+      return TextUtils.join(PATTERN_SEPARATOR, parts);
     } else {
-      return REGEX_MARKER_START + path + REGEX_MARKER_END;
+      return REGEX_MARKER_START + pattern + REGEX_MARKER_END;
     }
   }
 


### PR DESCRIPTION
## Problem ##

When running Robolectric in windows os, following error can occur. 

```java
java.util.regex.PatternSyntaxException: Unexpected internal error near index 1
\
	at java.base/java.util.regex.Pattern.error(Pattern.java:2027)
	at java.base/java.util.regex.Pattern.compile(Pattern.java:1788)
	at java.base/java.util.regex.Pattern.<init>(Pattern.java:1428)
	at java.base/java.util.regex.Pattern.compile(Pattern.java:1068)
	at java.base/java.lang.String.split(String.java:2317)
	at java.base/java.lang.String.split(String.java:2364)
	at ch.qos.logback.core.rolling.helper.FileFinder.regexEscapePath(Unknown Source)
	at ch.qos.logback.core.rolling.helper.FileNamePattern.toRegex(Unknown Source)
	at ch.qos.logback.core.rolling.helper.DateParser.<init>(Unknown Source)
	at ch.qos.logback.core.rolling.helper.TimeBasedArchiveRemover.<init>(Unknown Source)
	at ch.qos.logback.core.rolling.helper.SizeAndTimeBasedArchiveRemover.<init>(Unknown Source)
	at ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP.createArchiveRemover(Unknown Source)
	at ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP.start(Unknown Source)
	at ch.qos.logback.core.rolling.TimeBasedRollingPolicy.start(Unknown Source)
```

Because `String.split()` method use a regex parameter,  but there may be a  `\`  in windows OS. 

## Resolving ##

In logback,  log path was slashified,  so i always use a `/` to split pattern and path.
