### PR TITLE
feat: Shorter log on property file not exists

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/joran/action/PropertyAction.java
@@ -74,7 +74,7 @@ public class PropertyAction extends Action {
         FileInputStream istream = new FileInputStream(file);
         loadAndSetProperties(ec, istream, scope);
       } catch (FileNotFoundException e) {
-        addError("Could not find properties file [" + file + "].", e);
+        addError("Could not find properties file [" + file + "].");
       } catch (IOException e1) {
         addError("Could not read properties file [" + file + "].", e1);
       }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When property file included by configuration not exists then an ERROR log with long exception trace is populated.
The trace with `java.io.FileNotFoundException` is not useful as it contains no additional information and only increases the log size. This merge requests removed the trace from the ERROR log.

### Linked Issues


### Additional context

In **qos-ch/logback** this is implemented this way as well. See https://github.com/qos-ch/logback/blob/master/logback-core/src/main/java/ch/qos/logback/core/model/processor/PropertyModelHandler.java#L51

<!-- e.g. is there anything you'd like reviewers to focus on? -->
