### PR TITLE
ci: fix daily scheduled workflow failures

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -4,14 +4,36 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  issues: write
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest
     steps:
       - name: need reproduction
-        uses: actions-cool/issues-helper@v3
+        uses: actions/github-script@v8
         with:
-          actions: "close-issues"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "need reproduction"
-          inactive-day: 3
+          script: |
+            const inactiveDays = 3;
+            const cutoff = new Date(Date.now() - inactiveDays * 24 * 60 * 60 * 1000);
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'need reproduction',
+              per_page: 100,
+            });
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+              if (new Date(issue.updated_at) < cutoff) {
+                console.log(`Closing #${issue.number} (last updated ${issue.updated_at})`);
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+              }
+            }

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -11,7 +11,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-inactive-days: "14"


### PR DESCRIPTION
## Summary

The two daily scheduled workflows (`Issue Close Require` and `Lock Closed Issues`) have failed every night for weeks. This PR fixes both root causes:

### Issue Close Require — action repository disabled by GitHub

Every run fails at the download step with `##[error]Repository access blocked`. The `actions-cool/issues-helper` repository was **disabled by GitHub Staff for a terms-of-service violation**, so the action can never be downloaded again — no version pin can fix it.

Replaced it with an equivalent `actions/github-script@v8` step (official, first-party action) that reproduces the original behavior: close open issues labeled `need reproduction` after 3 days of inactivity (closed as `not_planned`). Also added an explicit least-privilege `permissions: issues: write` block, which the workflow previously lacked.

### Lock Closed Issues — token validation broken in lock-threads v4

Every run fails with `##[error]"github-token" length must be less than or equal to 100 characters long`. GitHub's newer `GITHUB_TOKEN` format exceeds the `Joi.string().max(100)` input validation in `dessant/lock-threads` v4 (and v5). v6 raised the limit to 1000 chars, so this is a one-line version bump to `dessant/lock-threads@v6`. All existing inputs (`issue-inactive-days`, `issue-lock-reason`, `process-only: issues`) remain valid in v6.

## Testing

- Both workflow files pass YAML validation.
- Both workflows are `schedule`-only, so they can't be exercised from this PR branch; they will run against `main` at the next daily cron after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UriKjApFeo7s3VTpVYa2TA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UriKjApFeo7s3VTpVYa2TA)_