### PR TITLE
feat: allow apps to provide Android Context externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,44 @@ See [Wiki](https://github.com/tony19/logback-android/wiki) for documentation.
 7. Open logcat for your device (via the _Android Monitor_ tab in Android Studio).
 8. Click the app menu, and select the menu-option. You should see "hello world" in logcat.
 
+## Providing Android context externally
+
+In order to support various [special properties](https://github.com/tony19/logback-android/wiki#special-properties-for-xml-config) the code requires
+access to an Android [Context](https://developer.android.com/reference/android/content/Context) instance. By default, the framework uses a workaround based
+on reflection that seems to work for the time being. However, in view of Google's [restrictions on non-SDK interfaces](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces)
+this code might not work anymore. Therefore, the framework provides a special API that enables the application to provide an Android context instance that
+will be used instead of the workaround. **Note:** the context instance must be provided *before* it is needed by the framework, so the best place for it
+would be in the application's *onCreate* callback:
+
+```java
+public class MyApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        // Assuming no logging occurs before this
+        AndroidContextUtil.setApplicationContext(this);
+    }
+}
+```
+
+If an earlier initialization is required, then one might consider overriding `attachBaseContext`, although at this stage the context instance might not be
+fully initialized. This might be good enough though if by the time the context is used by the framework it becomes fully initialized.
+
+```java
+public class MyApplication extends Application {
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        AndroidContextUtil.setApplicationContext(base);
+    }
+}
+```
+
+*Note:* despite the fact that the method is called `setApplicationContext` - the user may use *any* `ContextWrapper` component (*Application, Activity, Service*) - the
+framework will actually use the ["pure" application context](https://developer.android.com/reference/android/content/Context#getApplicationContext()).
+
 
 ## Download
 

--- a/logback-android/build.gradle
+++ b/logback-android/build.gradle
@@ -6,8 +6,8 @@ android {
     buildToolsVersion '30.0.3'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_6
-        targetCompatibility JavaVersion.VERSION_1_6
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
     }
 
     defaultConfig {

--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -16,7 +16,6 @@
 package ch.qos.logback.core.android;
 
 import android.annotation.TargetApi;
-import android.content.ContextWrapper;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
@@ -25,6 +24,7 @@ import android.os.Environment;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
 
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.CoreConstants;
@@ -37,14 +37,16 @@ import ch.qos.logback.core.CoreConstants;
  * @since 1.0.8-1
  */
 public class AndroidContextUtil {
-  private ContextWrapper context;
+  private static final AtomicReference<android.content.Context> CONTEXT_HOLDER = new AtomicReference<>();
+
+  private final android.content.Context context;
 
   public AndroidContextUtil() {
     this(getContext());
   }
 
-  public AndroidContextUtil(ContextWrapper contextWrapper) {
-    this.context = contextWrapper;
+  public AndroidContextUtil(android.content.Context context) {
+    this.context = (context == null) ? null : context.getApplicationContext();
   }
 
   public static boolean containsProperties(String value) {
@@ -71,11 +73,31 @@ public class AndroidContextUtil {
     context.putProperty(CoreConstants.VERSION_NAME_KEY, getVersionName());
   }
 
-  protected static ContextWrapper getContext() {
+  /**
+   * Provides an Android {@link android.content.Context} for the framework to use
+   * instead of the reflection-based workaround (which may break under Google's
+   * restrictions on non-SDK interfaces). The application context is extracted and
+   * retained, so any {@link android.content.ContextWrapper} (Application, Activity,
+   * Service) may be passed. This must be called before the context is first needed
+   * by the framework (e.g. in the application's {@code onCreate}).
+   *
+   * @param context the context to use; pass {@code null} to clear it
+   */
+  public static void setApplicationContext(android.content.Context context) {
+    CONTEXT_HOLDER.set((context == null) ? null : context.getApplicationContext());
+  }
+
+  protected static android.content.Context getContext() {
+    android.content.Context context = CONTEXT_HOLDER.get();
+    if (context != null) {
+      return context.getApplicationContext();
+    }
+
     try {
       Class<?> c = Class.forName("android.app.AppGlobals");
       Method method = c.getDeclaredMethod("getInitialApplication");
-      return (ContextWrapper)method.invoke(c);
+      context = (android.content.Context) method.invoke(c);
+      return (context == null) ? null : context.getApplicationContext();
     } catch (ClassNotFoundException e) {
       //e.printStackTrace();
     } catch (NoSuchMethodException e) {
@@ -116,10 +138,10 @@ public class AndroidContextUtil {
    *
    * @return the absolute path to the external storage directory
    */
-  @TargetApi(8)
+  @TargetApi(Build.VERSION_CODES.FROYO)
   @SuppressWarnings("deprecation")
   public String getExternalStorageDirectoryPath() {
-    if (Build.VERSION.SDK_INT >= 29) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       return getExternalFilesDirectoryPath();
     } else {
       return absPath(Environment.getExternalStorageDirectory());
@@ -134,7 +156,7 @@ public class AndroidContextUtil {
    *
    * @return the absolute path to the external storage directory
    */
-  @TargetApi(8)
+  @TargetApi(Build.VERSION_CODES.FROYO)
   public String getExternalFilesDirectoryPath() {
     return this.context != null
             ? absPath(this.context.getExternalFilesDir(null))
@@ -185,9 +207,9 @@ public class AndroidContextUtil {
    * @return the absolute path to the files directory
    * (example: "/data/data/com.example/nobackup/files")
    */
-  @TargetApi(21)
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public String getNoBackupFilesDirectoryPath() {
-    return Build.VERSION.SDK_INT >= 21 &&
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
             this.context != null
             ? absPath(this.context.getNoBackupFilesDir())
             : "";
@@ -201,10 +223,8 @@ public class AndroidContextUtil {
    * (example: "/data/data/com.example/databases")
    */
   public String getDatabaseDirectoryPath() {
-    return this.context != null
-            && this.context.getDatabasePath("x") != null
-            ? this.context.getDatabasePath("x").getParent()
-            : "";
+    File dbPath = (this.context == null) ? null : this.context.getDatabasePath("x");
+    return (dbPath != null) ? dbPath.getParent() : "";
   }
 
   public String getDatabasePath(String databaseName) {
@@ -217,8 +237,11 @@ public class AndroidContextUtil {
     String versionCode = "";
     if (this.context != null) {
       try {
-        PackageInfo pkgInfo = this.context.getPackageManager().getPackageInfo(getPackageName(), 0);
-        versionCode = "" + pkgInfo.versionCode;
+        PackageManager pm = this.context.getPackageManager();
+        PackageInfo pkgInfo = pm.getPackageInfo(getPackageName(), 0);
+        versionCode = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                ? Long.toString(pkgInfo.getLongVersionCode())
+                : Integer.toString(pkgInfo.versionCode);
       } catch (PackageManager.NameNotFoundException e) {
       }
     }
@@ -229,7 +252,8 @@ public class AndroidContextUtil {
     String versionName = "";
     if (this.context != null) {
       try {
-        PackageInfo pkgInfo = this.context.getPackageManager().getPackageInfo(getPackageName(), 0);
+        PackageManager pm = this.context.getPackageManager();
+        PackageInfo pkgInfo = pm.getPackageInfo(getPackageName(), 0);
         versionName = pkgInfo.versionName;
       } catch (PackageManager.NameNotFoundException e) {
       }
@@ -237,7 +261,7 @@ public class AndroidContextUtil {
     return versionName != null ? versionName : "";
   }
 
-  private String absPath(File file) {
+  private static String absPath(File file) {
     return file != null ? file.getAbsolutePath() : "";
   }
 }

--- a/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
@@ -21,12 +21,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowEnvironment;
 
 import ch.qos.logback.classic.LoggerContext;
@@ -44,7 +47,38 @@ public class AndroidContextUtilTest {
   @Before
   public void before() {
     ShadowEnvironment.reset();
+    // Ensure no context leaked in from a prior test's setApplicationContext() call
+    AndroidContextUtil.setApplicationContext(null);
     contextUtil = new AndroidContextUtil();
+  }
+
+  @After
+  public void after() {
+    // Reset the static holder so it doesn't leak into other tests
+    AndroidContextUtil.setApplicationContext(null);
+  }
+
+  @Test
+  public void setApplicationContextIsUsedInsteadOfReflectionWorkaround() {
+    android.content.Context appContext = RuntimeEnvironment.getApplication();
+    AndroidContextUtil.setApplicationContext(appContext);
+    assertThat(AndroidContextUtil.getContext(), is(appContext.getApplicationContext()));
+  }
+
+  @Test
+  public void noArgConstructorPicksUpProvidedContext() {
+    android.content.Context appContext = RuntimeEnvironment.getApplication();
+    AndroidContextUtil.setApplicationContext(appContext);
+    // The no-arg constructor resolves its context through getContext(), so it
+    // should observe the externally provided context.
+    assertThat(new AndroidContextUtil().getPackageName(), is(appContext.getPackageName()));
+  }
+
+  @Test
+  public void setApplicationContextNullFallsBackToReflectionWorkaround() {
+    AndroidContextUtil.setApplicationContext(RuntimeEnvironment.getApplication());
+    AndroidContextUtil.setApplicationContext(null);
+    assertThat(AndroidContextUtil.getContext(), is(notNullValue()));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This is a reviewed and touched-up version of **#361** (by @lgoldstein), opened as a draft for your review as part of the open-PR triage.

It adds a public API — `AndroidContextUtil.setApplicationContext(Context)` — so an application can supply the Android `Context` explicitly instead of relying on the reflection-based `AppGlobals.getInitialApplication()` workaround, which may stop working under Google's [non-SDK interface restrictions](https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces).

- The provided context is reduced to its application context and stored in a static `AtomicReference`.
- `getContext()` now prefers the externally provided context and falls back to the existing reflection workaround when none was set.
- The constructor now takes `android.content.Context` (a supertype of the old `ContextWrapper`, so existing source callers keep compiling).
- Hardcoded API-level literals were modernized to `Build.VERSION_CODES.*`, and `getVersionCode()` uses `getLongVersionCode()` on API 28+.

## What I changed on top of #361

1. **Fixed the README example.** The docs referenced a non-existent `AndroidContextUtils` class (plural); corrected to `AndroidContextUtil` so the snippets compile.
2. **Added test coverage** in `AndroidContextUtilTest` for the new API: that a provided context is used, that the no-arg constructor picks it up, and that clearing it falls back to reflection. The static holder is now reset in `@Before`/`@After` so it can't leak between tests.

## Notes / things to confirm

- `build.gradle` bumps `sourceCompatibility`/`targetCompatibility` from Java 1.6 → 1.7 (carried over from #361, and required by the `new AtomicReference<>()` diamond operator). This is harmless on all supported Android versions but is a deliberate baseline change worth a nod.
- I couldn't run the Android/Gradle build in this environment (no SDK; Gradle distribution download is blocked), so CI is the real verification here.
- This overlaps conceptually with your in-flight Kotlin/AGP-8 modernization drafts (#388–#390); if you'd rather fold this in there, that's easy to do.

Credit for the original change goes to @lgoldstein (#361).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBrtdK6G1WtVPvCxenWAXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBrtdK6G1WtVPvCxenWAXz)_