### PR TITLE
ci: add Copilot code review configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,56 @@
+# Copilot instructions for logback-android
+
+These instructions guide GitHub Copilot code review and Copilot Chat for this
+repository. `logback-android` is a lite port of [logback](http://logback.qos.ch)
+for Android, providing a configurable logging framework (files, SQLite, logcat,
+sockets, syslog, email).
+
+## Project facts
+
+- **Language / build:** Java, built with Gradle (`./gradlew`). The library module
+  lives under `logback-android/`.
+- **Minimum Android API:** 21+ (older docs mention API 9). Keep code compatible
+  with the project's configured `minSdk`; avoid APIs newer than the supported
+  range without guarding them.
+- **Java level:** Match the source/target compatibility already set in the Gradle
+  build. Do not introduce language features above that level.
+- **Tests:** JUnit tests live under `logback-android/src/test/java`. Run with
+  `./gradlew test`.
+- **Upstream parity:** Much of the code mirrors upstream logback. Prefer changes
+  that stay close to upstream behavior and naming so the port remains easy to
+  sync.
+
+## What to focus on in reviews
+
+- **Correctness of logging behavior:** appenders, encoders, layouts, filters, and
+  configuration (`logback.xml` / Joran) parsing. Watch for regressions in log
+  ordering, level filtering, and marker handling.
+- **Thread safety:** logging is called from arbitrary threads. Flag shared mutable
+  state without synchronization, and check that appenders handle concurrent
+  `append()` calls safely.
+- **Resource handling:** files, streams, sockets, and database handles must be
+  closed (prefer try-with-resources). Flag leaks, especially in appenders and
+  rolling policies.
+- **Android constraints:** avoid heavy work on the main thread, avoid reflection
+  that breaks under R8/ProGuard, and keep dependencies minimal. Flag use of
+  desktop-JVM-only APIs not available on Android.
+- **Null safety and input validation:** configuration comes from untrusted XML;
+  validate and fail gracefully rather than throwing raw NPEs.
+- **Performance:** logging is on hot paths. Flag unnecessary allocations, string
+  concatenation in place of parameterized logging, and work done even when a log
+  level is disabled.
+- **Backward compatibility:** this is a published library. Flag breaking changes
+  to public APIs, and note when a change needs a `@Deprecated` transition instead.
+
+## Style
+
+- Follow the surrounding code's formatting and naming; match upstream logback
+  conventions where the file is a port.
+- Keep public API changes documented (Javadoc) and covered by tests.
+- Prefer small, focused changes; call out unrelated refactors mixed into a PR.
+
+## What not to flag
+
+- Existing upstream code style that predates the change under review.
+- Generated or vendored files.
+- Minor stylistic nits that a formatter would handle — focus on substance.

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,39 @@
+name: Request Copilot Review
+
+# Automatically request a GitHub Copilot code review when a pull request is
+# opened or reopened. Copilot follows the guidance in
+# .github/copilot-instructions.md.
+#
+# Requires "Copilot code review" to be enabled for the repository
+# (Settings > Copilot). If Copilot is unavailable the request step is a no-op
+# and the workflow still succeeds.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    # Skip drafts and PRs from forks (the token cannot request reviewers there).
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/pulls/${PR}/requested_reviewers" \
+            -f "reviewers[]=copilot-pull-request-reviewer[bot]" \
+            || echo "Copilot review could not be requested (Copilot may be disabled for this repo); continuing."


### PR DESCRIPTION
## Summary

Sets up GitHub Copilot code review for this repository so pull requests get an automated, project-aware review.

Two additions:

- **`.github/copilot-instructions.md`** — repository custom instructions that steer Copilot's review (and Copilot Chat) with project-specific context: it's a Java/Gradle Android port of logback, so reviews should focus on logging correctness (appenders/encoders/layouts/Joran config), thread safety, resource/stream/socket handling, Android/R8 constraints, performance on hot paths, and public-API backward compatibility. Also notes what *not* to flag (pre-existing upstream style, vendored files, formatter nits).
- **`.github/workflows/copilot-review.yml`** — a workflow that automatically requests a Copilot review when a PR is opened or reopened. It skips drafts and fork PRs (where the token can't add reviewers) and tolerates Copilot being disabled, so the step never fails the run.

## Notes

- Automatic review requires **Copilot code review** to be enabled for the repository (Settings → Copilot). Until then, the workflow runs cleanly but the request is a no-op.
- The workflow uses `pull_request_target` with only `pull-requests: write` permission and does not check out or run PR code.

## Test plan

- [x] `copilot-review.yml` validated as well-formed YAML.
- [ ] After enabling Copilot for the repo, open a test PR and confirm `copilot-pull-request-reviewer[bot]` is added as a reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSvhJgMUUPro3hjKZWekGr)_