### PR TITLE
fix(rolling): don't delete non-expired period dirs during async cleanup

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/TimeBasedArchiveRemover.java
@@ -22,7 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -59,10 +61,44 @@ public class TimeBasedArchiveRemover extends ContextAwareBase implements Archive
       this.capTotalSize(files);
     }
 
+    Set<String> retainedDirs = this.retainedPeriodDirs(now);
     List<String> emptyDirs = this.findEmptyDirs();
     for (String dir : emptyDirs) {
+      // Never delete a directory belonging to a non-expired period, even if it
+      // currently appears empty. This cleanup runs asynchronously, so a retained
+      // period's directory can be momentarily empty while its active file is being
+      // (re)created or compressed on another thread. Deleting it then races with,
+      // and can destroy, the current period's freshly created directory.
+      if (retainedDirs.contains(new File(dir).getAbsolutePath())) {
+        continue;
+      }
       this.delete(new File(dir));
     }
+  }
+
+  /**
+   * Computes the directories (and their ancestors) of every non-expired period,
+   * i.e. the current period back through {@code maxHistory} periods. These must be
+   * protected from empty-directory removal because their contents may be transiently
+   * absent from disk while files are being created or compressed asynchronously.
+   */
+  private Set<String> retainedPeriodDirs(Date now) {
+    Set<String> dirs = new HashSet<String>();
+    int periodsToKeep = (this.maxHistory == CoreConstants.UNBOUND_HISTORY) ? 0 : this.maxHistory;
+    for (int i = 0; i <= periodsToKeep; i++) {
+      Date periodStart = this.rc.getEndOfNextNthPeriod(now, -i);
+      // convertMultipleArguments (not convert) so patterns that also contain an
+      // integer token (%i, size-and-time based rollover) are handled: each token
+      // consumes only its applicable argument. Only the directory is used, which
+      // is determined by the date token, so the integer value is irrelevant.
+      String path = this.fileNamePattern.convertMultipleArguments(periodStart, Integer.valueOf(0));
+      File dir = new File(path).getParentFile();
+      while (dir != null) {
+        dirs.add(dir.getAbsolutePath());
+        dir = dir.getParentFile();
+      }
+    }
+    return dirs;
   }
 
   private boolean delete(File file) {


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure (a `NullPointerException` in `TimeBasedRollingWithArchiveRemoval_Test.monthlyRolloverOverManyPeriods`) that was surfacing on unrelated PRs — notably the migration to the new GitHub Actions build. The failure is a real race in the archive-removal code, not a test-only artifact.

## Root cause

`TimeBasedArchiveRemover.clean()` deleted **any** empty directory matching the file-name pattern, with no date guard:

```java
List<String> emptyDirs = this.findEmptyDirs();
for (String dir : emptyDirs) {
  this.delete(new File(dir));   // deletes even the current period's dir
}
```

Cleanup runs **asynchronously** — it's scheduled inside `rollover()` *before* the appender opens the new active file. So when rolling into a new period there's a brief window where the current period's directory (e.g. `2021/01`) exists but its `clean.txt` has not been created yet. The async cleanup lists that directory as empty and deletes it — along with its now-empty parent (`2021`). The subsequent file creation then fails, and the test's `new File(ROOT_DIR, "2021/01").list()` returns `null` → `Arrays.asList(null)` → NPE.

The same window also lets a *retained archive* directory be deleted while its file is mid-compression (rename → compress), so the guard needs to protect all non-expired periods, not just the current one.

## Fix

Guard empty-directory removal so directories belonging to non-expired periods — the current period back through `maxHistory` — are never deleted. The protected set is computed **by date** (via the rolling calendar and the file-name pattern), so it's independent of transient on-disk state. Expired period directories and their now-empty parents are still removed exactly as before.

## Validation

The failure is a ~0.4% race, so it can't be caught by a single test run. I extracted the pure-core rolling classes and replayed the exact `monthlyRolloverOverManyPeriods` scenario in a loop:

- **Before the fix:** ~0.4% of runs failed (e.g. 2/500) — either the current period's directory or a mid-compression archive directory was destroyed.
- **After the fix:** 1500/1500 runs passed, while still asserting that expired period directories (and their empty parent year-directories) are removed — confirming retention behavior is unchanged.

## Scope

- Single-file change: `TimeBasedArchiveRemover.java`.
- No change to which files/periods are retained; only prevents the async cleanup from destroying directories of periods that are supposed to be kept.

Marked draft so CI can exercise the full test suite across the rolling patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUuFruzfXa8Atpu4iKMf7f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUuFruzfXa8Atpu4iKMf7f)_