### PR TITLE
ci: deploy logback-android to mavenLocal for logback-test-app check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,27 +82,52 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      # The downstream logback-test-app uses a newer Android Gradle plugin that
-      # requires JDK 17, matching the library build.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # JDK 17: required to build logback-android (see the build job) and by the
+      # newer Android Gradle plugin the downstream logback-test-app uses.
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
 
-      - name: Checkout app code
-        run: git clone https://github.com/tony19-sandbox/logback-test-app.git
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-      - name: Download release AAR
-        uses: actions/download-artifact@v4
+      # android-31 / build-tools 30.0.3 build logback-android (matching the build
+      # job); android-36 / build-tools 36.0.0 are what logback-test-app compiles
+      # against (compileSdk 36, buildToolsVersion '36.0.0').
+      - name: Install Android SDK packages
+        uses: android-actions/setup-android@v3
         with:
-          name: logback-android-release-aar
-          path: aar
+          packages: 'platform-tools platforms;android-31 platforms;android-36 build-tools;30.0.3 build-tools;36.0.0'
 
-      - name: Copy logback-android to app libs
+      # Read the versions being tested so logback-test-app can be pointed at the
+      # build-under-test instead of its released default.
+      - name: Read versions under test
+        id: versions
         run: |
-          mkdir -p logback-test-app/app/libs
-          cp aar/logback-android-release.aar logback-test-app/app/libs/.
+          echo "logback=$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+          echo "slf4j=$(grep '^slf4jVersion=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
 
+      # Deploy the build-under-test to the local Maven repo (~/.m2), where
+      # logback-test-app resolves com.github.tony19:logback-android from. Signing
+      # is skipped automatically since CI configures no PGP keys (see
+      # gradle/publish-module.gradle); mavenLocal consumers don't need signatures.
+      - name: Publish logback-android to Maven local
+        run: ./gradlew publishToMavenLocal --no-configuration-cache
+
+      # Use the tagged release of the test app so the CI flow is reproducible.
+      - name: Checkout app code
+        run: git clone --branch v0.0.2 --depth 1 https://github.com/tony19-sandbox/logback-test-app.git
+
+      # logback-test-app resolves com.github.tony19:logback-android:${logbackAndroidVersion}
+      # from mavenLocal; override its released default with the build-under-test.
       - name: Test app
-        run: cd logback-test-app && ./gradlew test
+        run: |
+          cd logback-test-app
+          ./gradlew test \
+            -PlogbackAndroidVersion=${{ steps.versions.outputs.logback }} \
+            -Pslf4jVersion=${{ steps.versions.outputs.slf4j }}

--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -78,10 +78,19 @@ afterEvaluate {
 }
 
 signing {
-    useInMemoryPgpKeys(
-            rootProject.ext["signing.keyId"],
-            rootProject.ext["signing.key"],
-            rootProject.ext["signing.password"],
-    )
-    sign publishing.publications
+    def signingKey = rootProject.ext["signing.key"]
+    // Only sign when a signing key is configured (release CI sets SIGNING_KEY).
+    // Without this guard, `sign publishing.publications` attaches unmet `.asc`
+    // artifacts to the publication, so `publishToMavenLocal` fails when no keys
+    // are present. Skipping signing lets the logback-android CI (and local
+    // developers) deploy the build-under-test to mavenLocal for logback-test-app.
+    required { signingKey }
+    if (signingKey) {
+        useInMemoryPgpKeys(
+                rootProject.ext["signing.keyId"],
+                signingKey,
+                rootProject.ext["signing.password"],
+        )
+        sign publishing.publications
+    }
 }


### PR DESCRIPTION
## Summary

`logback-test-app` was changed (tagged release **v0.0.2**) to resolve `com.github.tony19:logback-android` from `mavenLocal()` via `${logbackAndroidVersion}`, instead of the old flatDir `app/libs/*.aar` copy. This lets logback-android's own CI validate the build-under-test by deploying it locally before running the app's tests. This PR wires the CI to that flow.

## Changes

**`.github/workflows/build.yml` — `test_app` job**
- Check out logback-android, set up Gradle, and install the Android SDK packages both builds need (`android-31` + `build-tools;30.0.3` for logback-android; `android-36` + `build-tools;36.0.0` for the app).
- Deploy the build-under-test with `./gradlew publishToMavenLocal` (replacing the download-artifact + copy-to-`app/libs` steps).
- Clone the **tagged** `logback-test-app` **v0.0.2** for a reproducible flow.
- Run the app tests with `-PlogbackAndroidVersion` / `-Pslf4jVersion` read from `gradle.properties` (`VERSION_NAME` / `slf4jVersion`), so the app resolves the version being tested rather than its released default.

**`gradle/publish-module.gradle` — guard signing on key presence**
- `publishToMavenLocal` previously failed without PGP keys: `sign publishing.publications` always attached `.asc` signature artifacts that were never produced. Signing is now only applied when `SIGNING_KEY` is configured, so CI (and local developers) can publish to mavenLocal without keys. Release CI is unaffected because it sets `SIGNING_KEY`.

## Verification

- Reproduced the `signing { sign publishing.publications }` + `afterEvaluate` publication idiom in a standalone Gradle project and confirmed:
  - unguarded `publishToMavenLocal` fails at `signReleasePublication` (`Could not read PGP secret key`);
  - `-x signReleasePublication` still fails (`.asc` artifact does not exist);
  - the key-presence guard publishes cleanly to `~/.m2` with a valid pom/aar/module.
- Confirmed logback-test-app v0.0.2 uses `mavenLocal()` first and reads `logbackAndroidVersion` / `slf4jVersion` (default `2.0.1` / `1.7.36`), overridable via `-P`.
- Confirmed logback-android 3.0.1-SNAPSHOT ships the SLF4J 2.x `SLF4JServiceProvider`, so `slf4jVersion=2.0.7` is the correct override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPnZjKcxomkrskGzuX8N9k)_