### PR TITLE
fix: correct logback.xsd regex escape; ship consumer ProGuard rules in the AAR

### DIFF
--- a/logback-android/build.gradle
+++ b/logback-android/build.gradle
@@ -5,6 +5,13 @@ android {
     namespace 'com.github.tony19.logback.android'
     compileSdk = 35
 
+    defaultConfig {
+        // packaged into the AAR and applied to consuming apps automatically;
+        // logback-android is configured reflectively (from logback.xml), so
+        // consumers' R8 builds break without these rules (issues #378, #380)
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+
     // JDK-specific builds: each flavor pins a Java bytecode target and the
     // matching Android runtime floor, published as separate artifacts:
     //

--- a/logback-android/consumer-rules.pro
+++ b/logback-android/consumer-rules.pro
@@ -1,8 +1,23 @@
-# Issue #229
--keepclassmembers class ch.qos.logback.classic.pattern.* { <init>(); }
-
-# The following rules should only be used if you plan to keep
-# the logging calls in your released app.
--keepclassmembers ch.qos.logback.** { *; }
--keepclassmembers org.slf4j.impl.** { *; }
+# R8/ProGuard rules shipped inside the AAR and applied automatically to
+# consuming apps (issues #229, #344, #352, #364, #378, #380).
+#
+# logback-android is configured almost entirely through reflection: Joran
+# instantiates the appenders, encoders, layouts, and rolling policies named
+# in logback.xml by class name, sets their properties via reflective setter
+# lookup, and PatternLayout resolves %converters through a class-name map.
+# R8 cannot trace any of those references, so without these rules it strips
+# or renames classes (e.g. DateTokenConverter, the rolling-policy classes)
+# and logging fails only in minified release builds.
+-keep class ch.qos.logback.** { *; }
+-keep class org.slf4j.impl.** { *; }
 -keepattributes *Annotation*
+
+# Keep the app's custom appenders, which are typically referenced only by
+# class name inside logback.xml.
+-keep class * implements ch.qos.logback.core.Appender { *; }
+
+# SMTPAppender's javax.mail/javax.activation dependency is optional
+# (compileOnly); suppress R8 missing-class errors when the app doesn't
+# bundle it.
+-dontwarn javax.mail.**
+-dontwarn javax.activation.**

--- a/logback-android/src/test/java/ch/qos/logback/core/joran/LogbackSchemaTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/joran/LogbackSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package ch.qos.logback.core.joran;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -64,6 +65,8 @@ public class LogbackSchemaTest {
   public void schemaCompiles() throws Exception {
     Schema schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
         .newSchema(new StreamSource(schemaFile));
+    assertNotNull("schema failed to compile", schema);
+
     // validate a representative config, including a property reference as a
     // level value, which is what the pattern facets on line ~782 exist for
     String config =

--- a/logback-android/src/test/java/ch/qos/logback/core/joran/LogbackSchemaTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/joran/LogbackSchemaTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.joran;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * Sanity checks for the published logback.xsd (issue #381).
+ *
+ * The JDK's schema compiler (Xerces) accepts some escape sequences that the
+ * XML Schema spec forbids, while stricter validators (e.g. libxml2/xmllint)
+ * reject the entire schema. So in addition to compiling the schema, verify
+ * that every pattern facet uses only spec-legal escapes.
+ */
+public class LogbackSchemaTest {
+
+  private File schemaFile;
+
+  @Before
+  public void setup() {
+    // unit tests run with the module directory as the working directory;
+    // the schema lives at the repository root
+    schemaFile = new File("../logback.xsd");
+    if (!schemaFile.isFile()) {
+      schemaFile = new File("logback.xsd");
+    }
+    assertTrue("logback.xsd not found relative to " + new File(".").getAbsolutePath(),
+        schemaFile.isFile());
+  }
+
+  @Test
+  public void schemaCompiles() throws Exception {
+    Schema schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+        .newSchema(new StreamSource(schemaFile));
+    // validate a representative config, including a property reference as a
+    // level value, which is what the pattern facets on line ~782 exist for
+    String config =
+        "<configuration xmlns='https://tony19.github.io/logback-android/xml'>" +
+        "  <appender name='logcat' class='ch.qos.logback.classic.android.LogcatAppender'>" +
+        "    <encoder><pattern>%msg%n</pattern></encoder>" +
+        "  </appender>" +
+        "  <root level='${LOG_LEVEL}'>" +
+        "    <appender-ref ref='logcat'/>" +
+        "  </root>" +
+        "</configuration>";
+    schema.newValidator().validate(new StreamSource(new StringReader(config)));
+  }
+
+  @Test
+  public void patternFacetsUseOnlyLegalEscapes() throws Exception {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setNamespaceAware(true);
+    DocumentBuilder db = dbf.newDocumentBuilder();
+    Document doc = db.parse(new InputSource(schemaFile.toURI().toString()));
+
+    NodeList patterns = doc.getElementsByTagNameNS(XMLConstants.W3C_XML_SCHEMA_NS_URI, "pattern");
+    assertTrue("expected pattern facets in schema", patterns.getLength() > 0);
+
+    List<String> errors = new ArrayList<String>();
+    for (int i = 0; i < patterns.getLength(); i++) {
+      String value = patterns.item(i).getAttributes().getNamedItem("value").getNodeValue();
+      String error = findIllegalEscape(value);
+      if (error != null) {
+        errors.add("pattern \"" + value + "\": " + error);
+      }
+    }
+    if (!errors.isEmpty()) {
+      fail("illegal escape sequences in logback.xsd (rejected by strict XSD validators):\n"
+          + String.join("\n", errors));
+    }
+  }
+
+  /**
+   * Returns a description of the first escape sequence in the given XSD regex
+   * that is not permitted by https://www.w3.org/TR/xmlschema-2/#regexs
+   * (SingleCharEsc, MultiCharEsc, catEsc/complEsc), or null if all are legal.
+   * Note {@code \$} is NOT a legal escape: {@code $} has no special meaning in
+   * XSD regexes and must appear unescaped.
+   */
+  private static String findIllegalEscape(String regex) {
+    final String singleCharEscapes = "nrt\\|.?*+(){}-[]^";
+    final String multiCharEscapes = "sSiIcCdDwW";
+    for (int i = 0; i < regex.length() - 1; i++) {
+      if (regex.charAt(i) != '\\') {
+        continue;
+      }
+      char escaped = regex.charAt(++i);
+      if (escaped == 'p' || escaped == 'P') {
+        continue; // category escape; brace content checked by schema compiler
+      }
+      if (singleCharEscapes.indexOf(escaped) < 0 && multiCharEscapes.indexOf(escaped) < 0) {
+        return "illegal escape sequence \\" + escaped;
+      }
+    }
+    return null;
+  }
+}

--- a/logback.xsd
+++ b/logback.xsd
@@ -779,7 +779,7 @@ fetches the remote schema definition.
                     <xsd:pattern value="($\{.+:-)?[Ii][Nn][Ff][Oo]\}?"/>
                     <xsd:pattern value="($\{.+:-)?[Dd][Ee][Bb][Uu][Gg]\}?"/>
                     <xsd:pattern value="($\{.+:-)?[Tt][Rr][Aa][Cc][Ee]\}?"/>
-                    <xsd:pattern value="\$\{.+\}"/>
+                    <xsd:pattern value="$\{.+\}"/>
                 </xsd:restriction>
             </xsd:simpleType>
         </xsd:union>


### PR DESCRIPTION
Fixes two recently reported bugs:

## `logback.xsd` invalid regex escape (fixes #381)

The level-value pattern facet on line 782 used `\$\{.+\}`, but `\$` is not a legal escape in XML Schema regular expressions (`$` has no special meaning there and must appear unescaped). The JDK's schema compiler tolerates it, but strict validators such as libxml2/xmllint reject the **entire schema**:

```
logback.xsd:782: element pattern: Schemas parser error : ... The value '\$\{.+\}'
of the facet 'pattern' is not a valid regular expression.
```

- Dropped the backslash to match the sibling patterns in the same facet: `$\{.+\}`
- Added `LogbackSchemaTest`, which compiles the schema, validates a representative config (including a `${VAR}` level value, which is what this facet exists for), and scans every pattern facet for spec-illegal escapes. The escape scan is needed because the JDK's Xerces is lenient and would not catch this regression on its own.

Verified: `xmllint --schema logback.xsd` fails to compile the schema before the fix and validates configs cleanly after it; the new test fails against the old schema and passes against the fixed one.

## Consumer ProGuard rules were never shipped (fixes #380, fixes #378)

`logback-android/consumer-rules.pro` has existed since the module was created, but it was never referenced by `consumerProguardFiles`, so it was never packaged into the AAR — consumers got no R8 rules at all. The file's contents were also broken: `-keepclassmembers` was missing the `class` keyword (a syntax error, as reported in #380), and member-only rules are insufficient anyway because R8 strips the classes themselves (the root cause of #378's `FileNamePattern ... does not contain a valid DateToken` crash, where the rolling helpers were stripped from minified builds).

- Wired `consumer-rules.pro` into the build via `consumerProguardFiles` in `defaultConfig`
- Replaced its contents with rules based on the configurations reporters verified working in #378 and #380:
  - keep `ch.qos.logback.**` and `org.slf4j.impl.**` (Joran instantiates components named in `logback.xml` reflectively and sets properties via reflective setter lookup, so R8 cannot trace any of it)
  - keep app-defined `Appender` implementations, which are typically referenced only by class name inside `logback.xml`
  - `-dontwarn javax.mail.**` / `javax.activation.**` for SMTPAppender's optional (`compileOnly`) dependency

With this, apps using `minifyEnabled true` work out of the box without hand-written keep rules, and the ProGuard section of the wiki becomes optional guidance rather than a requirement.

## Notes

- The AAR packaging couldn't be verified in this sandbox (no network access to `dl.google.com` for AGP/SDK), so CI's `assembleRelease` is the verification for the `consumerProguardFiles` wiring. The schema test was verified standalone with JUnit against both the old and new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_