### PR TITLE
feat: LayoutWrappingEncoder support, transitive slf4j-api, getMarkerList compat

### DIFF
--- a/logback-android/build.gradle
+++ b/logback-android/build.gradle
@@ -126,7 +126,11 @@ dependencies {
     }
     testImplementation project(path: ':logback-android')
 
-    compileOnly "org.slf4j:slf4j-api:${slf4jVersion}"
+    // 'api' so slf4j-api appears as a compile-scope dependency in the
+    // published POM; consumers previously had to add it by hand and got
+    // NoClassDefFoundError (SLF4JServiceProvider) when a transitive
+    // slf4j-api 1.x won dependency resolution instead (issue #359)
+    api "org.slf4j:slf4j-api:${slf4jVersion}"
 
     // For SMTPAppender
     compileOnly 'com.sun.mail:android-mail:1.6.8'

--- a/logback-android/src/main/java/ch/qos/logback/classic/android/LogcatAppender.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/android/LogcatAppender.java
@@ -22,6 +22,8 @@ import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.joran.spi.DefaultClass;
 
 /**
  * An appender that wraps the native Android logging mechanism (<i>logcat</i>);
@@ -44,8 +46,8 @@ public class LogcatAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
    * http://developer.android.com/reference/android/util/Log.html#isLoggable(java.lang.String, int)
    */
   private static final int MAX_TAG_LENGTH = 23;
-  private PatternLayoutEncoder encoder = null;
-  private PatternLayoutEncoder tagEncoder = null;
+  private LayoutWrappingEncoder<ILoggingEvent> encoder = null;
+  private LayoutWrappingEncoder<ILoggingEvent> tagEncoder = null;
   private boolean checkLoggable = false;
 
   /**
@@ -77,15 +79,26 @@ public class LogcatAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
       // prevent stack traces from showing up in the tag
       // (which could lead to very confusing error messages)
       if (layout instanceof PatternLayout) {
-        String pattern = this.tagEncoder.getPattern();
-        if (!pattern.contains("%nopex")) {
-          this.tagEncoder.stop();
-          this.tagEncoder.setPattern(pattern + "%nopex");
-          this.tagEncoder.start();
+        if (this.tagEncoder instanceof PatternLayoutEncoder) {
+          PatternLayoutEncoder tagPatternEncoder = (PatternLayoutEncoder) this.tagEncoder;
+          String pattern = tagPatternEncoder.getPattern();
+          if (!pattern.contains("%nopex")) {
+            // restarting the encoder rebuilds its layout from the new pattern
+            tagPatternEncoder.stop();
+            tagPatternEncoder.setPattern(pattern + "%nopex");
+            tagPatternEncoder.start();
+          }
+          ((PatternLayout) this.tagEncoder.getLayout()).setPostCompileProcessor(null);
+        } else {
+          PatternLayout tagLayout = (PatternLayout) layout;
+          String pattern = tagLayout.getPattern();
+          if (pattern != null && !pattern.contains("%nopex")) {
+            tagLayout.stop();
+            tagLayout.setPostCompileProcessor(null);
+            tagLayout.setPattern(pattern + "%nopex");
+            tagLayout.start();
+          }
         }
-
-        PatternLayout tagLayout = (PatternLayout) layout;
-        tagLayout.setPostCompileProcessor(null);
       }
     }
 
@@ -145,29 +158,32 @@ public class LogcatAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
   }
 
   /**
-   * Gets the pattern-layout encoder for this appender's <i>logcat</i> message
+   * Gets the layout-wrapping encoder for this appender's <i>logcat</i> message
    *
-   * @return the pattern-layout encoder
+   * @return the layout-wrapping encoder
    */
-  public PatternLayoutEncoder getEncoder() {
+  public LayoutWrappingEncoder<ILoggingEvent> getEncoder() {
     return this.encoder;
   }
 
   /**
-   * Sets the pattern-layout encoder for this appender's <i>logcat</i> message
+   * Sets the layout-wrapping encoder for this appender's <i>logcat</i> message.
+   * This is a {@link PatternLayoutEncoder} in most configurations, but any
+   * {@link LayoutWrappingEncoder} with a layout is accepted (issue #376).
    *
-   * @param encoder the pattern-layout encoder
+   * @param encoder the layout-wrapping encoder
    */
-  public void setEncoder(PatternLayoutEncoder encoder) {
+  @DefaultClass(PatternLayoutEncoder.class)
+  public void setEncoder(LayoutWrappingEncoder<ILoggingEvent> encoder) {
     this.encoder = encoder;
   }
 
   /**
-   * Gets the pattern-layout encoder for this appender's <i>logcat</i> tag
+   * Gets the layout-wrapping encoder for this appender's <i>logcat</i> tag
    *
-   * @return the pattern encoder
+   * @return the layout-wrapping encoder
    */
-  public PatternLayoutEncoder getTagEncoder() {
+  public LayoutWrappingEncoder<ILoggingEvent> getTagEncoder() {
     return this.tagEncoder;
   }
 
@@ -187,10 +203,12 @@ public class LogcatAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
    * (in this case: <code>f.f.foo.foo.bar.Test</code>).
    *
    * @param encoder
-   *            the pattern-layout encoder; specify {@code null} to
+   *            the layout-wrapping encoder (a {@link PatternLayoutEncoder}
+   *            in most configurations); specify {@code null} to
    *            automatically use the logger's name as the tag
    */
-  public void setTagEncoder(PatternLayoutEncoder encoder) {
+  @DefaultClass(PatternLayoutEncoder.class)
+  public void setTagEncoder(LayoutWrappingEncoder<ILoggingEvent> encoder) {
     this.tagEncoder = encoder;
   }
 

--- a/logback-android/src/main/java/ch/qos/logback/classic/spi/ILoggingEvent.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/spi/ILoggingEvent.java
@@ -73,6 +73,19 @@ public interface ILoggingEvent extends DeferredProcessingAware {
   List<Marker> getMarkers();
 
   /**
+   * Synonym for {@link #getMarkers()}, matching the method name used by
+   * logback-classic 1.3+ so that code shared between logback-android and
+   * logback-classic (e.g. custom encoders exercised by JVM unit tests
+   * that substitute logback-classic) compiles and runs against both
+   * (issue #365).
+   *
+   * @return the markers associated with this event
+   */
+  default List<Marker> getMarkerList() {
+    return getMarkers();
+  }
+
+  /**
    * @return the MDC map. The returned value can be an empty map but not null.
    */
   Map<String, String> getMDCPropertyMap();

--- a/logback-android/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/rolling/TimeBasedFileNamingAndTriggeringPolicyBase.java
@@ -82,7 +82,12 @@ abstract public class TimeBasedFileNamingAndTriggeringPolicyBase<E> extends
       }
     }
 
-    addInfo("Setting initial period to " + dateInCurrentPeriod);
+    // Date#toString looks up timezone display names through android.icu,
+    // which crashes on devices with corrupted ICU data (issue #373); a
+    // numeric-offset format avoids that lookup entirely
+    addInfo("Setting initial period to "
+            + new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS Z", Locale.US)
+                    .format(dateInCurrentPeriod));
     computeNextCheck();
   }
 

--- a/logback-android/src/test/java/ch/qos/logback/classic/android/LogcatAppenderTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/android/LogcatAppenderTest.java
@@ -26,13 +26,17 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowLog;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
+import ch.qos.logback.core.joran.spi.JoranException;
 
 /**
  * Tests the {@link LogcatAppender} class
@@ -103,7 +107,7 @@ public class LogcatAppenderTest {
   private void setTagPattern(String tag, boolean checkLoggable) {
     logcatAppender.stop();
     logcatAppender.setCheckLoggable(checkLoggable);
-    logcatAppender.getTagEncoder().setPattern(tag);
+    ((PatternLayoutEncoder) logcatAppender.getTagEncoder()).setPattern(tag);
     logcatAppender.start();
   }
 
@@ -182,5 +186,64 @@ public class LogcatAppenderTest {
     ShadowLog.reset();
     context.getLogger(LOGGER_NAME).debug("msg", new NullPointerException());
     assertLogcatContains(Log.DEBUG, NullPointerException.class.getName());
+  }
+
+  /**
+   * Issue #376
+   */
+  @Test
+  public void supportsLayoutWrappingEncoder() throws JoranException {
+    String config =
+        "<configuration>" +
+        "  <appender name='logcat' class='ch.qos.logback.classic.android.LogcatAppender'>" +
+        "    <encoder class='ch.qos.logback.core.encoder.LayoutWrappingEncoder'>" +
+        "      <layout class='ch.qos.logback.classic.PatternLayout'>" +
+        "        <pattern>wrapped: %msg</pattern>" +
+        "      </layout>" +
+        "    </encoder>" +
+        "  </appender>" +
+        "  <root level='DEBUG'><appender-ref ref='logcat'/></root>" +
+        "</configuration>";
+    LogcatAppender appender = configureFromXml(config);
+
+    assertThat(appender.isStarted(), is(true));
+    assertThat(appender.getEncoder(), is(instanceOf(LayoutWrappingEncoder.class)));
+
+    LoggingEvent event = new LoggingEvent();
+    event.setMessage("hello");
+    assertThat(appender.getEncoder().getLayout().doLayout(event), is("wrapped: hello"));
+  }
+
+  /**
+   * Issue #376: an encoder element without a class attribute must still
+   * default to PatternLayoutEncoder
+   */
+  @Test
+  public void defaultEncoderTypeIsPatternLayoutEncoder() throws JoranException {
+    String config =
+        "<configuration>" +
+        "  <appender name='logcat' class='ch.qos.logback.classic.android.LogcatAppender'>" +
+        "    <encoder><pattern>%msg</pattern></encoder>" +
+        "    <tagEncoder><pattern>tag</pattern></tagEncoder>" +
+        "  </appender>" +
+        "  <root level='DEBUG'><appender-ref ref='logcat'/></root>" +
+        "</configuration>";
+    LogcatAppender appender = configureFromXml(config);
+
+    assertThat(appender.isStarted(), is(true));
+    assertThat(appender.getEncoder(), is(instanceOf(PatternLayoutEncoder.class)));
+    assertThat(appender.getTagEncoder(), is(instanceOf(PatternLayoutEncoder.class)));
+  }
+
+  private LogcatAppender configureFromXml(String config) throws JoranException {
+    LoggerContext ctx = new LoggerContext();
+    JoranConfigurator configurator = new JoranConfigurator();
+    configurator.setContext(ctx);
+    configurator.doConfigure(new ByteArrayInputStream(config.getBytes()));
+
+    LogcatAppender appender = (LogcatAppender) ctx
+        .getLogger(Logger.ROOT_LOGGER_NAME).getAppender("logcat");
+    assertThat(appender, is(notNullValue()));
+    return appender;
   }
 }

--- a/logback-android/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/spi/LoggingEventTest.java
@@ -34,6 +34,18 @@ public class LoggingEventTest {
   }
 
 
+  // Issue #365: getMarkerList is logback-classic's name for getMarkers
+  @Test
+  public void markerListIsSynonymForMarkers() {
+    LoggingEvent event = new LoggingEvent("", logger, Level.INFO, "msg", null, null);
+    org.slf4j.Marker marker = org.slf4j.MarkerFactory.getMarker("EVENT_365");
+    event.setMarkers(java.util.Collections.singletonList(marker));
+
+    assertEquals(event.getMarkers(), event.getMarkerList());
+    assertEquals(1, event.getMarkerList().size());
+    assertEquals(marker, event.getMarkerList().get(0));
+  }
+
   @Test
   public void testFormattingOneArg() {
     String message = "x={}";


### PR DESCRIPTION
Second round of issue-triage fixes, addressing four long-standing reports:

## `LogcatAppender` accepts any `LayoutWrappingEncoder` (fixes #376)

`LogcatAppender` declared its `encoder`/`tagEncoder` properties as `PatternLayoutEncoder`, so configs assigning a plain `LayoutWrappingEncoder` (e.g. wrapping a custom masking layout, per the Baeldung sensitive-data guide the reporter followed) failed with "object is not assignable" and the appender never started — even though the appender only ever uses the encoder's layout.

- Both properties are widened to `LayoutWrappingEncoder<ILoggingEvent>`
- The setters carry `@DefaultClass(PatternLayoutEncoder.class)`, so `<encoder>`/`<tagEncoder>` elements **without** a `class` attribute still default to `PatternLayoutEncoder` — existing configs are unaffected
- The `%nopex` tag protection handles both shapes: a `PatternLayoutEncoder` is restarted with the amended pattern as before; a generic encoder over a `PatternLayout` has the pattern amended on the layout directly
- New tests: the exact #376 config shape (`LayoutWrappingEncoder` + nested `PatternLayout`) and a regression test that class-less `<encoder>` still defaults to `PatternLayoutEncoder`

Note: `getEncoder()`/`getTagEncoder()` return types changed from `PatternLayoutEncoder` to `LayoutWrappingEncoder<ILoggingEvent>`, which is a source-level change for Java/Kotlin callers that assigned the result to a `PatternLayoutEncoder` variable (hence `feat:`).

## slf4j-api is now a transitive dependency (fixes #359)

`slf4j-api` was `compileOnly`, so it never appeared in the published POM: every consumer had to add it by hand, and when another library pulled in slf4j-api 1.x transitively there was no 2.x constraint from logback-android to win conflict resolution — apps crashed with `ClassNotFoundException: org.slf4j.spi.SLF4JServiceProvider`. It's now declared with `api` (compile scope in the POM), matching upstream logback-classic and the `slf4j-*` modules.

## `ILoggingEvent.getMarkerList()` compat synonym (fixes #365)

logback-android's slf4j-2.x port named the marker accessor `getMarkers()` while logback-classic 1.3+ named it `getMarkerList()`, so code shared between the two (custom encoders exercised by JVM unit tests that substitute logback-classic, as the README suggests) couldn't compile/run against both. Added `getMarkerList()` as a default method delegating to `getMarkers()`, with a test.

## Avoid ICU timezone-name lookup at rolling-policy startup (refs #373)

The "Setting initial period" status message stringified a `java.util.Date`; `Date#toString` resolves timezone display names through `android.icu`, which throws `IndexOutOfBoundsException` inside `ICUBinary` on devices with corrupted ICU data (reported on Samsung Android 13 builds), crashing apps in `TimeBasedRollingPolicy.start()`. The message now formats the timestamp with a numeric UTC offset, which never touches the ICU name tables. The underlying corruption is a platform bug (not unit-testable — it depends on broken firmware data) and can still surface via `%d` patterns that use timezone-name tokens, but the library's own startup path no longer triggers it.

## Verification

The Android SDK isn't reachable from this sandbox, so instead of the Gradle build: all 411 main sources plus the touched test classes were compiled against Robolectric's `android-all` jar, and the new behavior was exercised directly — the #376 config starts and formats through the custom layout, class-less encoders still default to `PatternLayoutEncoder`, tag output excludes stack traces for both encoder shapes, and `getMarkerList()` mirrors `getMarkers()` (LoggingEventTest passes 5/5). CI runs the full suite.

Branch note: rebased onto current `main` (post-#418, post-AGP-9 modernization); the previously merged commits are not re-included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q