### PR TITLE
fix: rollover durability — no malformed archives or lost logs on abrupt app death

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/FileAppender.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/FileAppender.java
@@ -56,6 +56,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
   private boolean prudent = false;
   private boolean initialized = false;
   private boolean lazyInit = false;
+  private boolean syncOnFlush = false;
 
   private FileSize bufferSize = new FileSize(DEFAULT_BUFFER_SIZE);
 
@@ -223,6 +224,7 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
 
       ResilientFileOutputStream resilientFos = new ResilientFileOutputStream(file, append, bufferSize.getSize());
       resilientFos.setContext(context);
+      resilientFos.setSyncOnFlush(syncOnFlush);
       setOutputStream(resilientFos);
       successful = true;
     } finally {
@@ -277,6 +279,30 @@ public class FileAppender<E> extends OutputStreamAppender<E> {
   public void setBufferSize(FileSize bufferSize) {
     addInfo("Setting bufferSize to ["+bufferSize.toString()+"]");
     this.bufferSize = bufferSize;
+  }
+
+  /**
+   * @see #setSyncOnFlush(boolean)
+   *
+   * @return true if every flush also syncs the file descriptor
+   */
+  public boolean isSyncOnFlush() {
+    return syncOnFlush;
+  }
+
+  /**
+   * When true, every flush of the log stream also forces the bytes down to
+   * the storage device (fsync). Combined with the default
+   * {@code immediateFlush}, each event is durable against an abrupt
+   * power-off — not just against the process being killed, which an
+   * ordinary flush already survives — at the cost of a slower write per
+   * event (issue #371). Consider wrapping the appender in an
+   * {@code AsyncAppender} if the extra latency matters. Defaults to false.
+   *
+   * @param syncOnFlush true to fsync on every flush
+   */
+  public void setSyncOnFlush(boolean syncOnFlush) {
+    this.syncOnFlush = syncOnFlush;
   }
 
   private void safeWrite(E event) throws IOException {

--- a/logback-android/src/main/java/ch/qos/logback/core/recovery/ResilientFileOutputStream.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/recovery/ResilientFileOutputStream.java
@@ -22,6 +22,7 @@ public class ResilientFileOutputStream extends ResilientOutputStreamBase {
 
   private File file;
   private FileOutputStream fos;
+  private boolean syncOnFlush;
 
 
   public ResilientFileOutputStream(File file, boolean append, long bufferSize) throws FileNotFoundException {
@@ -29,6 +30,36 @@ public class ResilientFileOutputStream extends ResilientOutputStreamBase {
     fos = new FileOutputStream(file, append);
     this.os = new BufferedOutputStream(fos, (int) bufferSize);
     this.presumedClean = true;
+  }
+
+  /**
+   * Sets whether each {@link #flush()} also forces the file descriptor to
+   * sync to the storage device (fsync), so already-flushed bytes survive an
+   * abrupt power-off and not just a process kill.
+   *
+   * @param syncOnFlush true to fsync on every flush
+   */
+  public void setSyncOnFlush(boolean syncOnFlush) {
+    this.syncOnFlush = syncOnFlush;
+  }
+
+  @Override
+  public void flush() {
+    super.flush();
+    if (syncOnFlush && fos != null) {
+      try {
+        fos.getFD().sync();
+      } catch (IOException e) {
+        postIOFailure(e);
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    // flush (and fsync, if enabled) anything still buffered before closing
+    flush();
+    super.close();
   }
 
   public FileChannel getChannel() {

--- a/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/rolling/helper/Compressor.java
@@ -44,6 +44,17 @@ public class Compressor extends ContextAwareBase {
 
   static final int BUFFER_SIZE = 8192;
 
+  // Compression streams into "<target><TMP_SUFFIX>" and atomically renames to
+  // the final archive name only after a fully successful write, so an app
+  // killed mid-compression can never leave a malformed archive behind
+  // (issue #369)
+  static final String TMP_SUFFIX = ".tmp";
+
+  // a temp file untouched for this long cannot belong to an in-flight
+  // compression (which writes continuously), so it's a leftover from an
+  // interrupted rollover and safe to sweep
+  static final long STALE_TMP_AGE_MS = 30 * 60 * 1000;
+
   public Compressor(CompressionMode compressionMode) {
     this.compressionMode = compressionMode;
   }
@@ -97,12 +108,15 @@ public class Compressor extends ContextAwareBase {
 
     addInfo("ZIP compressing [" + file2zip + "] as ["+zippedFile+"]");
     createMissingTargetDirsIfNecessary(zippedFile);
+    deleteStaleTempFiles(zippedFile);
 
+    File tmpFile = new File(nameOfZippedFile + TMP_SUFFIX);
+    boolean streamed = false;
     BufferedInputStream bis = null;
     ZipOutputStream zos = null;
     try {
       bis = new BufferedInputStream(new FileInputStream(nameOfFile2zip));
-      zos = new ZipOutputStream(new FileOutputStream(nameOfZippedFile));
+      zos = new ZipOutputStream(new FileOutputStream(tmpFile));
 
       ZipEntry zipEntry = computeZipEntry(innerEntryName);
       zos.putNextEntry(zipEntry);
@@ -114,31 +128,22 @@ public class Compressor extends ContextAwareBase {
         zos.write(inbuf, 0, n);
       }
 
-      addInfo("Done ZIP compressing [" + file2zip + "] as [" + zippedFile + "]");
+      // close in-try so a failed close (i.e. an incomplete archive)
+      // counts as a failed compression
+      zos.close();
+      zos = null;
+      bis.close();
+      bis = null;
+      streamed = true;
     } catch (Exception e) {
       addStatus(new ErrorStatus("Error occurred while compressing ["
               + nameOfFile2zip + "] into [" + nameOfZippedFile + "].", this, e));
     } finally {
-      if (bis != null) {
-        try {
-          bis.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
-      if (zos != null) {
-        try {
-          zos.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
+      closeQuietly(bis);
+      closeQuietly(zos);
     }
 
-    if (!file2zip.delete()) {
-      addStatus(new WarnStatus("Could not delete [" + nameOfFile2zip + "].",
-              this));
-    }
+    finishCompression(file2zip, tmpFile, zippedFile, streamed);
   }
 
   // http://jira.qos.ch/browse/LBCORE-98
@@ -191,12 +196,15 @@ public class Compressor extends ContextAwareBase {
 
     addInfo("GZ compressing [" + file2gz + "] as ["+gzedFile+"]");
     createMissingTargetDirsIfNecessary(gzedFile);
+    deleteStaleTempFiles(gzedFile);
 
+    File tmpFile = new File(nameOfgzedFile + TMP_SUFFIX);
+    boolean streamed = false;
     BufferedInputStream bis = null;
     GZIPOutputStream gzos = null;
     try {
       bis = new BufferedInputStream(new FileInputStream(nameOfFile2gz));
-      gzos = new GZIPOutputStream(new FileOutputStream(nameOfgzedFile));
+      gzos = new GZIPOutputStream(new FileOutputStream(tmpFile));
       byte[] inbuf = new byte[BUFFER_SIZE];
       int n;
 
@@ -204,31 +212,84 @@ public class Compressor extends ContextAwareBase {
         gzos.write(inbuf, 0, n);
       }
 
-      addInfo("Done ZIP compressing [" + file2gz + "] as [" + gzedFile + "]");
-
+      // close in-try so a failed close (i.e. an incomplete archive)
+      // counts as a failed compression
+      gzos.close();
+      gzos = null;
+      bis.close();
+      bis = null;
+      streamed = true;
     } catch (Exception e) {
       addStatus(new ErrorStatus("Error occurred while compressing ["
               + nameOfFile2gz + "] into [" + nameOfgzedFile + "].", this, e));
     } finally {
-      if (bis != null) {
-        try {
-          bis.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
-      if (gzos != null) {
-        try {
-          gzos.close();
-        } catch (IOException e) {
-          // ignore
-        }
-      }
+      closeQuietly(bis);
+      closeQuietly(gzos);
     }
 
-    if (!file2gz.delete()) {
-      addStatus(new WarnStatus("Could not delete [" + nameOfFile2gz + "].",
-              this));
+    finishCompression(file2gz, tmpFile, gzedFile, streamed);
+  }
+
+  /**
+   * Promotes a fully written temp file to the final archive name and only
+   * then deletes the source file. On any failure, the source file is kept
+   * (no log data is lost) and the partial temp file is removed.
+   */
+  private void finishCompression(File sourceFile, File tmpFile, File targetFile, boolean streamed) {
+    boolean success = streamed;
+    if (success && !tmpFile.renameTo(targetFile)) {
+      addStatus(new ErrorStatus("Failed to rename compressed file ["
+              + tmpFile + "] to [" + targetFile + "].", this));
+      success = false;
+    }
+
+    if (success) {
+      addInfo("Done compressing [" + sourceFile + "] as [" + targetFile + "]");
+      if (!sourceFile.delete()) {
+        addStatus(new WarnStatus("Could not delete [" + sourceFile + "].",
+                this));
+      }
+    } else if (tmpFile.exists() && !tmpFile.delete()) {
+      addStatus(new WarnStatus("Could not delete temporary file [" + tmpFile
+              + "].", this));
+    }
+  }
+
+  /**
+   * Sweeps leftover temp files from compressions interrupted by an abrupt
+   * app kill (issue #369). Only files with a compression suffix directly
+   * followed by {@value #TMP_SUFFIX} are candidates — by construction those
+   * are partial archives, never original log data — and only when untouched
+   * for {@link #STALE_TMP_AGE_MS}, so in-flight compressions in the same
+   * directory are never disturbed.
+   */
+  private void deleteStaleTempFiles(File targetFile) {
+    File dir = targetFile.getAbsoluteFile().getParentFile();
+    if (dir == null) {
+      return;
+    }
+    File[] candidates = dir.listFiles((d, name) ->
+            name.endsWith(".gz" + TMP_SUFFIX) || name.endsWith(".zip" + TMP_SUFFIX));
+    if (candidates == null) {
+      return;
+    }
+    long cutoff = System.currentTimeMillis() - STALE_TMP_AGE_MS;
+    for (File candidate : candidates) {
+      long lastModified = candidate.lastModified();
+      if (lastModified > 0 && lastModified < cutoff && candidate.delete()) {
+        addInfo("Deleted stale temporary file [" + candidate
+                + "] left over from an interrupted compression");
+      }
+    }
+  }
+
+  private void closeQuietly(java.io.Closeable closeable) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (IOException e) {
+        // ignore
+      }
     }
   }
 

--- a/logback-android/src/test/java/ch/qos/logback/core/FileAppenderSyncOnFlushTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/FileAppenderSyncOnFlushTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import ch.qos.logback.core.encoder.EchoEncoder;
+import ch.qos.logback.core.status.StatusChecker;
+
+/**
+ * Tests the {@code syncOnFlush} option of {@link FileAppender}, which fsyncs
+ * the log file on every flush so already-written events survive an abrupt
+ * power-off (issue #371).
+ */
+public class FileAppenderSyncOnFlushTest {
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  private final Context context = new ContextBase();
+
+  @Test
+  public void eventsAreWrittenAndDurableWithSyncOnFlush() throws IOException {
+    File logFile = new File(tmpDir.getRoot(), "sync.log");
+
+    FileAppender<Object> appender = new FileAppender<Object>();
+    appender.setContext(context);
+    appender.setName("SYNC");
+    appender.setFile(logFile.getPath());
+    appender.setSyncOnFlush(true);
+    EchoEncoder<Object> encoder = new EchoEncoder<Object>();
+    encoder.setContext(context);
+    encoder.start();
+    appender.setEncoder(encoder);
+    appender.start();
+
+    assertTrue(appender.isStarted());
+    appender.doAppend("event 1");
+    appender.doAppend("event 2");
+
+    // with immediateFlush (default) + syncOnFlush, both events must be on
+    // disk before stop() — read the file while the appender is still open
+    String written = new String(Files.readAllBytes(logFile.toPath()), StandardCharsets.UTF_8);
+    assertEquals("event 1" + CoreConstants.LINE_SEPARATOR
+        + "event 2" + CoreConstants.LINE_SEPARATOR, written);
+
+    appender.stop();
+    StatusChecker checker = new StatusChecker(context);
+    assertTrue(checker.isErrorFree(0));
+  }
+}

--- a/logback-android/src/test/java/ch/qos/logback/core/rolling/helper/CompressorDurabilityTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/rolling/helper/CompressorDurabilityTest.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.rolling.helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.status.StatusChecker;
+
+/**
+ * Tests that an interrupted or failed compression can never lose log data or
+ * leave a malformed archive behind (issue #369).
+ */
+public class CompressorDurabilityTest {
+
+  private static final String CONTENT = "hello rollover durability\n";
+
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  private final Context context = new ContextBase();
+  private StatusChecker checker;
+
+  @Before
+  public void setup() {
+    checker = new StatusChecker(context);
+  }
+
+  private Compressor gzCompressor() {
+    Compressor compressor = new Compressor(CompressionMode.GZ);
+    compressor.setContext(context);
+    return compressor;
+  }
+
+  private File createSourceFile(String name) throws IOException {
+    File source = tmpDir.newFile(name);
+    FileOutputStream fos = new FileOutputStream(source);
+    fos.write(CONTENT.getBytes("UTF-8"));
+    fos.close();
+    return source;
+  }
+
+  private String gunzip(File gzFile) throws IOException {
+    GZIPInputStream in = new GZIPInputStream(new FileInputStream(gzFile));
+    try {
+      return readAll(in);
+    } finally {
+      in.close();
+    }
+  }
+
+  private String readAll(java.io.InputStream in) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    byte[] buf = new byte[1024];
+    int n;
+    while ((n = in.read(buf)) != -1) {
+      out.write(buf, 0, n);
+    }
+    return out.toString("UTF-8");
+  }
+
+  @Test
+  public void successfulGzCompressionLeavesNoTempFile() throws IOException {
+    File source = createSourceFile("app.log");
+    File target = new File(tmpDir.getRoot(), "app.log.gz");
+
+    gzCompressor().compress(source.getPath(), target.getPath(), null);
+
+    assertTrue(checker.isErrorFree(0));
+    assertTrue("archive missing", target.exists());
+    assertFalse("temp file left behind",
+        new File(target.getPath() + Compressor.TMP_SUFFIX).exists());
+    assertFalse("source not deleted", source.exists());
+    assertEquals(CONTENT, gunzip(target));
+  }
+
+  @Test
+  public void failedGzCompressionPreservesSourceFile() throws IOException {
+    File source = createSourceFile("app.log");
+    // parent "directory" of the target is a regular file, so opening the
+    // temp file for the archive must fail
+    File blocker = tmpDir.newFile("blocked");
+    File target = new File(blocker, "app.log.gz");
+
+    gzCompressor().compress(source.getPath(), target.getPath(), null);
+
+    assertTrue("compression failure must be reported",
+        checker.containsMatch("Error occurred while compressing"));
+    assertTrue("source file must survive a failed compression", source.exists());
+    assertEquals(CONTENT, readAll(new FileInputStream(source)));
+    assertFalse("no archive may exist after a failure", target.exists());
+    assertFalse("no temp file may remain after a failure",
+        new File(target.getPath() + Compressor.TMP_SUFFIX).exists());
+  }
+
+  @Test
+  public void interruptedCompressionCanBeRetried() throws IOException {
+    File source = createSourceFile("app.log");
+    File target = new File(tmpDir.getRoot(), "app.log.gz");
+
+    // a partial temp file left behind by a previous, abruptly killed
+    // compression of the same target
+    File staleTmp = new File(target.getPath() + Compressor.TMP_SUFFIX);
+    FileOutputStream fos = new FileOutputStream(staleTmp);
+    fos.write("garbage from a killed process".getBytes("UTF-8"));
+    fos.close();
+
+    gzCompressor().compress(source.getPath(), target.getPath(), null);
+
+    assertTrue(checker.isErrorFree(0));
+    assertTrue(target.exists());
+    assertFalse(staleTmp.exists());
+    assertEquals(CONTENT, gunzip(target));
+  }
+
+  @Test
+  public void staleTempFilesAreSwept() throws IOException {
+    // orphaned partial archives from compressions of other targets, killed
+    // long ago (mtime beyond the stale threshold)
+    File staleGz = tmpDir.newFile("old-period.log.gz" + Compressor.TMP_SUFFIX);
+    File staleZip = tmpDir.newFile("old-period.log.zip" + Compressor.TMP_SUFFIX);
+    long oldTime = System.currentTimeMillis() - Compressor.STALE_TMP_AGE_MS - 60_000;
+    assertTrue(staleGz.setLastModified(oldTime));
+    assertTrue(staleZip.setLastModified(oldTime));
+
+    // a fresh temp file (e.g. a concurrent in-flight compression) that must
+    // NOT be swept
+    File freshTmp = tmpDir.newFile("in-flight.log.gz" + Compressor.TMP_SUFFIX);
+
+    // a source-side temp file created by TimeBasedRollingPolicy's
+    // renameRawAndAsyncCompress: contains original log data (name has
+    // digits between the compression suffix and .tmp), must NOT be swept
+    File rawTmp = tmpDir.newFile("app.log.gz1234567890" + Compressor.TMP_SUFFIX);
+    assertTrue(rawTmp.setLastModified(oldTime));
+
+    File source = createSourceFile("app.log");
+    File target = new File(tmpDir.getRoot(), "app.log.gz");
+    gzCompressor().compress(source.getPath(), target.getPath(), null);
+
+    assertTrue(checker.isErrorFree(0));
+    assertFalse("stale gz temp file not swept", staleGz.exists());
+    assertFalse("stale zip temp file not swept", staleZip.exists());
+    assertTrue("fresh temp file must not be swept", freshTmp.exists());
+    assertTrue("uncompressed raw temp file (log data!) must not be swept", rawTmp.exists());
+  }
+
+  @Test
+  public void successfulZipCompressionLeavesNoTempFile() throws IOException {
+    File source = createSourceFile("app.log");
+    File target = new File(tmpDir.getRoot(), "app.log.zip");
+
+    Compressor compressor = new Compressor(CompressionMode.ZIP);
+    compressor.setContext(context);
+    compressor.compress(source.getPath(), target.getPath(), "app.log");
+
+    assertTrue(checker.isErrorFree(0));
+    assertTrue(target.exists());
+    assertFalse(new File(target.getPath() + Compressor.TMP_SUFFIX).exists());
+    assertFalse(source.exists());
+
+    ZipInputStream zin = new ZipInputStream(new FileInputStream(target));
+    try {
+      ZipEntry entry = zin.getNextEntry();
+      assertEquals("app.log", entry.getName());
+      assertEquals(CONTENT, readAll(zin));
+    } finally {
+      zin.close();
+    }
+  }
+
+  @Test
+  public void failedZipCompressionPreservesSourceFile() throws IOException {
+    File source = createSourceFile("app.log");
+    File blocker = tmpDir.newFile("blocked");
+    File target = new File(blocker, "app.log.zip");
+
+    Compressor compressor = new Compressor(CompressionMode.ZIP);
+    compressor.setContext(context);
+    compressor.compress(source.getPath(), target.getPath(), "app.log");
+
+    assertTrue(checker.containsMatch("Error occurred while compressing"));
+    assertTrue("source file must survive a failed compression", source.exists());
+    assertFalse(target.exists());
+    assertFalse(new File(target.getPath() + Compressor.TMP_SUFFIX).exists());
+  }
+}

--- a/logback.xsd
+++ b/logback.xsd
@@ -436,6 +436,12 @@ fetches the remote schema definition.
                     <xsd:appinfo><markdown>FileAppender</markdown></xsd:appinfo>
                 </xsd:annotation>
             </xsd:element>
+            <xsd:element name="syncOnFlush" minOccurs="0" type="xsd:boolean">
+                <xsd:annotation>
+                    <xsd:documentation>Sync the file descriptor to the storage device on every flush, making flushed log events durable against abrupt power-off at the cost of slower writes (<code>FileAppender</code>)</xsd:documentation>
+                    <xsd:appinfo><markdown>FileAppender</markdown></xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
             <xsd:element name="layout" minOccurs="0" type="Layout">
                 <xsd:annotation>
                     <xsd:documentation>Log event serialization layout</xsd:documentation>


### PR DESCRIPTION
Third round of issue triage, tackling the rollover durability reports.

## No malformed archives or lost logs on interrupted rollover (fixes #369)

The reporter's fleet kills the app right at midnight — mid-rollover — and ends up with malformed `.gz` archives. Three defects in `Compressor` conspired:

1. **Compression streamed straight into the final `.gz`/`.zip` name.** A kill mid-compression left a truncated archive that *looks* complete, is never repaired, and blocks any retry (`"exist already. Aborting"`).
2. **A failed compression still deleted the source file** — the delete ran unconditionally after the try/finally, so an exception (disk full, unwritable dir) silently destroyed that period's logs.
3. **Stranded temp files were never cleaned.** With the `file` property set, rollover renames the active log to `<name>.gz<nanotime>.tmp` before compressing; a kill leaves that data invisible to `maxHistory`/`totalSizeCap` cleanup forever.

The fix:

- Compression streams into `<target>.tmp` and **atomically renames** to the final name only after a fully successful write *and close* (close moved in-try, so a failed close counts as a failed compression). A malformed archive can no longer exist under the final name — after a kill you get the intact uncompressed source instead of a corrupt `.gz`.
- The source file is deleted **only after** the rename succeeds. On any failure the partial temp file is removed and the source is preserved.
- Stale `*.gz.tmp` / `*.zip.tmp` partials from previous kills are swept when a later compression runs in the same directory — only when untouched for 30+ minutes (an in-flight compression writes continuously, so it can't be swept), and the filter can't match the rename-stage `<name>.gz<digits>.tmp` files, which hold original log data.

New `CompressorDurabilityTest` covers: success leaves no temp file; failure preserves the source (both GZ and ZIP — this is the regression test for defect 2); an interrupted compression can be retried over its stale temp file; and the sweep removes old partials while sparing fresh temps and rename-stage data files.

## Opt-in `syncOnFlush` for power-off durability (refs #371)

The #371 reporter loses the tail of the log when the device is powered off. That's physics, not a bug: an ordinary flush hands bytes to the OS page cache, which survives a process kill but not a power-off — the kernel may not have written the tail back to flash yet. The only fix is `fsync`, which costs real latency, so it's opt-in:

```xml
<appender class="ch.qos.logback.core.rolling.RollingFileAppender">
  <file>...</file>
  <syncOnFlush>true</syncOnFlush>
  ...
</appender>
```

When enabled, every flush also syncs the file descriptor to the storage device, so with the default `immediateFlush` each event is durable the moment the append returns. The stream is also flushed (and synced) on close. Added to `FileAppender`, `ResilientFileOutputStream`, and the XML schema; a sync failure flows into the existing resilient-recovery path. Documented with the suggestion to pair it with `AsyncAppender` when write latency matters.

## Verification

Compiled all main sources and ran the tests standalone against Robolectric's `android-all` jar (Gradle/AGP can't run in this sandbox — `dl.google.com` blocked): the 6 new durability tests, the pre-existing `CompressTest` (3), the end-to-end `TimeBasedRollingTest` (10, exercises real GZ/ZIP rollovers through the new code), and the new `syncOnFlush` test all pass; the updated schema still validates configs using `syncOnFlush`. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_