### PR TITLE
fix: socket appender startup, external-dir properties, color converters, makejar.sh

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/classic/PatternLayout.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/PatternLayout.java
@@ -19,9 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import ch.qos.logback.classic.pattern.*;
+import ch.qos.logback.classic.pattern.color.HighlightingCompositeConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
+import ch.qos.logback.core.pattern.color.*;
 import ch.qos.logback.core.pattern.parser.Parser;
 
 /**
@@ -110,6 +112,27 @@ public class PatternLayout extends PatternLayoutBase<ILoggingEvent> {
     defaultConverterMap.put("n", LineSeparatorConverter.class.getName());
 
     defaultConverterMap.put("lsn", LocalSequenceNumberConverter.class.getName());
+
+    // ANSI color composite converters (issue #332); mainly for parity with
+    // configurations shared with regular logback, since logcat viewers do
+    // not render ANSI escape codes
+    defaultConverterMap.put("black", BlackCompositeConverter.class.getName());
+    defaultConverterMap.put("red", RedCompositeConverter.class.getName());
+    defaultConverterMap.put("green", GreenCompositeConverter.class.getName());
+    defaultConverterMap.put("yellow", YellowCompositeConverter.class.getName());
+    defaultConverterMap.put("blue", BlueCompositeConverter.class.getName());
+    defaultConverterMap.put("magenta", MagentaCompositeConverter.class.getName());
+    defaultConverterMap.put("cyan", CyanCompositeConverter.class.getName());
+    defaultConverterMap.put("white", WhiteCompositeConverter.class.getName());
+    defaultConverterMap.put("gray", GrayCompositeConverter.class.getName());
+    defaultConverterMap.put("boldRed", BoldRedCompositeConverter.class.getName());
+    defaultConverterMap.put("boldGreen", BoldGreenCompositeConverter.class.getName());
+    defaultConverterMap.put("boldYellow", BoldYellowCompositeConverter.class.getName());
+    defaultConverterMap.put("boldBlue", BoldBlueCompositeConverter.class.getName());
+    defaultConverterMap.put("boldMagenta", BoldMagentaCompositeConverter.class.getName());
+    defaultConverterMap.put("boldCyan", BoldCyanCompositeConverter.class.getName());
+    defaultConverterMap.put("boldWhite", BoldWhiteCompositeConverter.class.getName());
+    defaultConverterMap.put("highlight", HighlightingCompositeConverter.class.getName());
   }
 
   public PatternLayout() {

--- a/logback-android/src/main/java/ch/qos/logback/classic/pattern/color/HighlightingCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/pattern/color/HighlightingCompositeConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.classic.pattern.color;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.color.ANSIConstants;
+import ch.qos.logback.core.pattern.color.ForegroundCompositeConverterBase;
+
+/**
+ * Colors the child output according to the event's level: bold red for
+ * ERROR, red for WARN, blue for INFO, and the default color otherwise
+ * (issue #332). Used via {@code %highlight(...)}.
+ */
+public class HighlightingCompositeConverter extends ForegroundCompositeConverterBase<ILoggingEvent> {
+
+  @Override
+  protected String getForegroundColorCode(ILoggingEvent event) {
+    Level level = event.getLevel();
+    switch (level.toInt()) {
+      case Level.ERROR_INT:
+        return ANSIConstants.BOLD + ANSIConstants.RED_FG;
+      case Level.WARN_INT:
+        return ANSIConstants.RED_FG;
+      case Level.INFO_INT:
+        return ANSIConstants.BLUE_FG;
+      default:
+        return ANSIConstants.DEFAULT_FG;
+    }
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -179,6 +179,25 @@ public class CoreConstants {
   public static final String EXT_DIR_KEY = "EXT_DIR";
 
   /**
+   * The key under which the application's external files directory
+   * (i.e. {@code Context#getExternalFilesDir(null)}) is registered in the
+   * logger context. Unlike {@link #EXT_DIR_KEY}, this value does not depend
+   * on the Android version. The value is typically something like:
+   * "/storage/emulated/0/Android/data/com.example/files" and is absent when
+   * external storage is unavailable.
+   */
+  public static final String EXT_FILES_DIR_KEY = "EXT_FILES_DIR";
+
+  /**
+   * The key under which the application's external cache directory
+   * (i.e. {@code Context#getExternalCacheDir()}) is registered in the
+   * logger context. The value is typically something like:
+   * "/storage/emulated/0/Android/data/com.example/cache" and is absent when
+   * external storage is unavailable.
+   */
+  public static final String EXT_CACHE_DIR_KEY = "EXT_CACHE_DIR";
+
+  /**
    * The key under which the application package name is registered
    * in the logger context.
    */

--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -52,6 +52,8 @@ public class AndroidContextUtil {
   public static boolean containsProperties(String value) {
     return value.contains(CoreConstants.DATA_DIR_KEY)
             || value.contains(CoreConstants.EXT_DIR_KEY)
+            || value.contains(CoreConstants.EXT_FILES_DIR_KEY)
+            || value.contains(CoreConstants.EXT_CACHE_DIR_KEY)
             || value.contains(CoreConstants.PACKAGE_NAME_KEY)
             || value.contains(CoreConstants.VERSION_CODE_KEY)
             || value.contains(CoreConstants.VERSION_NAME_KEY);
@@ -67,6 +69,16 @@ public class AndroidContextUtil {
     final String extDir = getMountedExternalStorageDirectoryPath();
     if (extDir != null) {
       context.putProperty(CoreConstants.EXT_DIR_KEY, extDir);
+    }
+    // Android-version-independent paths to the app-specific external
+    // directories, writable without permissions on API 19+ (issue #181)
+    final String extFilesDir = getExternalFilesDirectoryPath();
+    if (extFilesDir != null && !extFilesDir.isEmpty()) {
+      context.putProperty(CoreConstants.EXT_FILES_DIR_KEY, extFilesDir);
+    }
+    final String extCacheDir = getExternalCacheDirectoryPath();
+    if (extCacheDir != null && !extCacheDir.isEmpty()) {
+      context.putProperty(CoreConstants.EXT_CACHE_DIR_KEY, extCacheDir);
     }
     context.putProperty(CoreConstants.PACKAGE_NAME_KEY, getPackageName());
     context.putProperty(CoreConstants.VERSION_CODE_KEY, getVersionCode());
@@ -119,7 +131,16 @@ public class AndroidContextUtil {
    */
   public String getMountedExternalStorageDirectoryPath() {
     String path = null;
-    String state = Environment.getExternalStorageState();
+    String state;
+    try {
+      state = Environment.getExternalStorageState();
+    } catch (RuntimeException e) {
+      // Environment.getExternalStorageState throws
+      // ArrayIndexOutOfBoundsException in processes without an external
+      // storage volume, e.g. shell-context tools started via app_process
+      // (issue #315); treat it the same as "not mounted"
+      return null;
+    }
     if (Environment.MEDIA_MOUNTED.equals(state) ||
         Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
       path = getExternalStorageDirectoryPath();

--- a/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
@@ -85,10 +85,13 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   private int acceptConnectionTimeout = DEFAULT_ACCEPT_CONNECTION_DELAY;
   private Duration eventDelayLimit = new Duration(DEFAULT_EVENT_DELAY_TIMEOUT);
   
+  private boolean lazyInit = false;
+
   private BlockingDeque<E> deque;
   private String peerId;
   private SocketConnector connector;
   private Future<?> task;
+  private boolean taskSubmitted = false;
 
   private volatile Socket socket;
 
@@ -137,25 +140,25 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
     }
 
     if (errorCount == 0) {
-      try {
-        address = InetAddress.getByName(remoteHost);
-      } catch (UnknownHostException ex) {
-        addError("unknown host: " + remoteHost);
-        errorCount++;
-      }
-    }
-
-    if (errorCount == 0) {
       deque = queueFactory.newLinkedBlockingDeque(queueSize);
       peerId = "remote peer " + remoteHost + ":" + port + ": ";
-      connector = createConnector(address, port, 0, reconnectionDelay.getMilliseconds());
-      task = getContext().getScheduledExecutorService().submit(new Runnable() {
-        public void run() {
-          connectSocketAndDispatchEvents();
-        }
-      });
+      // defer the dispatch task (and the host-name resolution it performs)
+      // until the first log event when lazy (issue #341)
+      if (!lazyInit) {
+        submitDispatchTask();
+      }
       super.start();
     }
+  }
+
+  private synchronized void submitDispatchTask() {
+    if (taskSubmitted) return;
+    taskSubmitted = true;
+    task = getContext().getScheduledExecutorService().submit(new Runnable() {
+      public void run() {
+        resolveHostAndDispatchEvents();
+      }
+    });
   }
 
   /**
@@ -165,7 +168,9 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   public void stop() {
     if (!isStarted()) return;
     CloseUtil.closeQuietly(socket);
-    task.cancel(true);
+    if (task != null) {
+      task.cancel(true);
+    }
     super.stop();
   }
 
@@ -175,6 +180,7 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   @Override
   protected void append(E event) {
     if (event == null || !isStarted()) return;
+    submitDispatchTask();
 
     try {
       final boolean inserted = deque.offer(event, eventDelayLimit.getMilliseconds(), TimeUnit.MILLISECONDS);
@@ -183,6 +189,39 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
       }
     } catch (InterruptedException e) {
       addError("Interrupted while appending event to SocketAppender", e);
+    }
+  }
+
+  private void resolveHostAndDispatchEvents() {
+    // Resolve the host name in the background task rather than in start()
+    // (issue #65): resolution does a network lookup, which must not run on
+    // the thread that initializes logging (often the main thread), and a
+    // device that is offline at startup would otherwise permanently disable
+    // this appender. Retry with the reconnection delay until resolved.
+    try {
+      while (!resolveRemoteHost()) {
+        long delayMs = (reconnectionDelay != null) ? reconnectionDelay.getMilliseconds() : 0;
+        if (delayMs <= 0) {
+          addError(peerId + "gave up resolving host (reconnectionDelay is zero)");
+          return;
+        }
+        Thread.sleep(delayMs);
+      }
+    } catch (InterruptedException ex) {
+      addInfo("shutting down before host resolution completed");
+      return;
+    }
+    connector = createConnector(address, port, 0, reconnectionDelay.getMilliseconds());
+    connectSocketAndDispatchEvents();
+  }
+
+  private boolean resolveRemoteHost() {
+    try {
+      address = InetAddress.getByName(remoteHost);
+      return true;
+    } catch (UnknownHostException ex) {
+      addWarn(peerId + "unknown host: " + remoteHost + " (will retry)");
+      return false;
     }
   }
 
@@ -303,6 +342,26 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
    * @return transformer object
    */
   protected abstract PreSerializationTransformer<E> getPST();
+
+  /**
+   * Gets the enable status of lazy initialization of the socket connection
+   *
+   * @return true if enabled; false otherwise
+   */
+  public boolean getLazy() {
+    return lazyInit;
+  }
+
+  /**
+   * Enables/disables lazy initialization of the socket connection. This
+   * defers the host-name resolution and connection until the first
+   * outgoing message (issue #341).
+   *
+   * @param enable true to enable lazy initialization; false otherwise
+   */
+  public void setLazy(boolean enable) {
+    lazyInit = enable;
+  }
 
   /**
    * The <b>RemoteHost</b> property takes the name of of the host where a corresponding server is running.

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * ANSI escape codes used by the color composite converters (issue #332)
+ */
+public class ANSIConstants {
+
+  public final static String ESC_START = "\033[";
+  public final static String ESC_END = "m";
+
+  public final static String BOLD = "1;";
+
+  public final static String BLACK_FG = "30";
+  public final static String RED_FG = "31";
+  public final static String GREEN_FG = "32";
+  public final static String YELLOW_FG = "33";
+  public final static String BLUE_FG = "34";
+  public final static String MAGENTA_FG = "35";
+  public final static String CYAN_FG = "36";
+  public final static String WHITE_FG = "37";
+  public final static String DEFAULT_FG = "39";
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlackCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlackCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a black foreground.
+ *
+ * @param <E> the event type
+ */
+public class BlackCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BLACK_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlueCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlueCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a blue foreground.
+ *
+ * @param <E> the event type
+ */
+public class BlueCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BLUE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldBlueCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldBlueCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldBlue foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldBlueCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.BLUE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldCyanCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldCyanCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldCyan foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldCyanCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.CYAN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldGreenCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldGreenCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldGreen foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldGreenCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.GREEN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldMagentaCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldMagentaCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldMagenta foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldMagentaCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.MAGENTA_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldRedCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldRedCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldRed foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldRedCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.RED_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldWhiteCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldWhiteCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldWhite foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldWhiteCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.WHITE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldYellowCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldYellowCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldYellow foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldYellowCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.YELLOW_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/CyanCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/CyanCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a cyan foreground.
+ *
+ * @param <E> the event type
+ */
+public class CyanCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.CYAN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+import ch.qos.logback.core.pattern.CompositeConverter;
+
+/**
+ * Base class for composite converters that wrap their child output in ANSI
+ * foreground-color escape codes, e.g. {@code %cyan(%logger)} (issue #332).
+ * Note that Android's logcat viewers generally do not render ANSI codes;
+ * these converters exist mainly so configurations shared with regular
+ * logback (where consoles do render them) work without errors.
+ *
+ * @param <E> the event type
+ */
+abstract public class ForegroundCompositeConverterBase<E> extends CompositeConverter<E> {
+
+  private final static String SET_DEFAULT_COLOR =
+          ANSIConstants.ESC_START + "0;" + ANSIConstants.DEFAULT_FG + ANSIConstants.ESC_END;
+
+  @Override
+  protected String transform(E event, String in) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(ANSIConstants.ESC_START);
+    sb.append(getForegroundColorCode(event));
+    sb.append(ANSIConstants.ESC_END);
+    sb.append(in);
+    sb.append(SET_DEFAULT_COLOR);
+    return sb.toString();
+  }
+
+  /**
+   * Derives the ANSI foreground color code to use for the given event
+   *
+   * @param event the event being rendered
+   * @return an ANSI foreground color code from {@link ANSIConstants}
+   */
+  abstract protected String getForegroundColorCode(E event);
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GrayCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GrayCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a gray foreground.
+ *
+ * @param <E> the event type
+ */
+public class GrayCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.BLACK_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GreenCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GreenCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a green foreground.
+ *
+ * @param <E> the event type
+ */
+public class GreenCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.GREEN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/MagentaCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/MagentaCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a magenta foreground.
+ *
+ * @param <E> the event type
+ */
+public class MagentaCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.MAGENTA_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/RedCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/RedCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a red foreground.
+ *
+ * @param <E> the event type
+ */
+public class RedCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.RED_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/WhiteCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/WhiteCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a white foreground.
+ *
+ * @param <E> the event type
+ */
+public class WhiteCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.WHITE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/YellowCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/YellowCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a yellow foreground.
+ *
+ * @param <E> the event type
+ */
+public class YellowCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.YELLOW_FG;
+  }
+}

--- a/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
@@ -109,7 +109,7 @@ public class PatternLayoutTest extends AbstractPatternLayoutBaseTest<ILoggingEve
     // no "conversion words" errors, and ANSI codes wrap the colored parts;
     // INFO highlights as blue (34), %cyan is 36
     assertThat(val, containsString("\033[34mINFO \033[0;39m"));
-    assertThat(val, containsString("\033[36mc.q.l.c.pattern.ConverterTest\033[0;39m"));
+    assertThat(val, containsString("\033[36mc.q.l.classic.pattern.ConverterTest\033[0;39m"));
     assertThat(val, containsString("Some message"));
   }
 

--- a/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
@@ -98,6 +98,21 @@ public class PatternLayoutTest extends AbstractPatternLayoutBaseTest<ILoggingEve
     assertThat(val, containsString("java.lang.Exception: Bogus exception"));
   }
 
+  // Issue #332: color composite converters must be registered so patterns
+  // shared with regular logback compile without errors
+  @Test
+  public void colorConvertersAreRegistered() {
+    pl.setPattern("%highlight(%-5level) %cyan(%logger{36}) - %msg");
+    pl.start();
+    String val = pl.doLayout(makeLoggingEvent("Some message", null));
+
+    // no "conversion words" errors, and ANSI codes wrap the colored parts;
+    // INFO highlights as blue (34), %cyan is 36
+    assertThat(val, containsString("\033[34mINFO \033[0;39m"));
+    assertThat(val, containsString("\033[36mc.q.l.c.pattern.ConverterTest\033[0;39m"));
+    assertThat(val, containsString("Some message"));
+  }
+
   @Test
   public void testCompositePattern() {
     pl.setPattern("%-56(%d %lo{20}) - %m%n");

--- a/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
@@ -205,4 +205,26 @@ public class AndroidContextUtilTest {
     assertThat(loggerContext.getProperty(CoreConstants.VERSION_NAME_KEY), is(contextUtil.getVersionName()));
     assertThat(loggerContext.getProperty(CoreConstants.PACKAGE_NAME_KEY), is(contextUtil.getPackageName()));
   }
+
+  // Issue #181
+  @Test
+  public void setupPropertiesIncludesExternalDirs() {
+    LoggerContext loggerContext = new LoggerContext();
+
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_FILES_DIR_KEY), is(nullValue()));
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_CACHE_DIR_KEY), is(nullValue()));
+
+    contextUtil.setupProperties(loggerContext);
+
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_FILES_DIR_KEY), is(contextUtil.getExternalFilesDirectoryPath()));
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_CACHE_DIR_KEY), is(contextUtil.getExternalCacheDirectoryPath()));
+  }
+
+  // Issue #181
+  @Test
+  public void containsPropertiesDetectsExternalDirKeys() {
+    assertThat(AndroidContextUtil.containsProperties("${EXT_FILES_DIR}/logs/app.log"), is(true));
+    assertThat(AndroidContextUtil.containsProperties("${EXT_CACHE_DIR}/logs/app.log"), is(true));
+    assertThat(AndroidContextUtil.containsProperties("/absolute/path/app.log"), is(false));
+  }
 }

--- a/logback-android/src/test/java/ch/qos/logback/core/net/AbstractSocketAppenderTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/net/AbstractSocketAppenderTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -159,8 +160,11 @@ public class AbstractSocketAppenderTest {
     verify(appender).addError(contains("Queue size must be greater than zero"));
   }
 
+  // Issue #65: host-name resolution happens in the background task with
+  // retries, so an unresolvable host (e.g. device offline at startup) no
+  // longer prevents the appender from starting
   @Test
-  public void failsToStartWithUnresolvableRemoteHost() throws Exception {
+  public void startsWithUnresolvableRemoteHostAndRetriesResolution() throws Exception {
 
     new NetworkTestUtil().assumeNoUnresolvedUrlFallback();
 
@@ -171,8 +175,31 @@ public class AbstractSocketAppenderTest {
     appender.start();
 
     // then
-    assertFalse(appender.isStarted());
-    verify(appender).addError(contains("unknown host"));
+    assertTrue(appender.isStarted());
+    verify(appender, timeout(TIMEOUT)).addWarn(contains("unknown host"));
+  }
+
+  // Issue #341
+  @Test
+  public void lazyInitDefersConnectionUntilFirstEvent() throws Exception {
+
+    // given
+    mockOneSuccessfulSocketConnection();
+    appender.setLazy(true);
+
+    // when
+    appender.start();
+
+    // then: started, but no connection attempt yet (the dispatch task is
+    // only submitted on the first append, so nothing runs asynchronously)
+    assertTrue(appender.isStarted());
+    verify(appender, never()).newConnector(any(InetAddress.class), anyInt(), anyLong(), anyLong());
+
+    // when
+    appender.append("some event");
+
+    // then
+    verify(appender, timeout(TIMEOUT)).newConnector(any(InetAddress.class), anyInt(), anyLong(), anyLong());
   }
 
   @Test

--- a/scripts/makejar.sh
+++ b/scripts/makejar.sh
@@ -1,7 +1,8 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 
 if [[ ! -z "$1" ]] && [[ "$1" != -r ]]; then
-  echo "Creates the uber jar in ./build"
+  echo "Creates the AAR in ./build"
   echo
   echo " Usage: $0 [-r]"
   echo
@@ -10,9 +11,15 @@ if [[ ! -z "$1" ]] && [[ "$1" != -r ]]; then
   exit 1
 fi
 
-. gradle.properties
+# Read VERSION_NAME from gradle.properties. Do NOT source the file: it is a
+# Java properties file, and lines like "org.gradle.jvmargs=-Xmx6g" are not
+# valid shell (issue #346).
+version=$(sed -n 's/^VERSION_NAME=//p' gradle.properties | tr -d '[:space:]')
+if [[ -z "$version" ]]; then
+  echo "error: VERSION_NAME not found in gradle.properties" >&2
+  exit 1
+fi
 
-version=${VERSION_NAME}
 _profile=Debug
 if [[ "$1" == "-r" ]]; then
   _profile=Release
@@ -20,5 +27,5 @@ if [[ "$1" == "-r" ]]; then
 fi
 
 ./gradlew clean assemble${_profile} -x test -PVERSION_NAME=${version}
-mkdir build
+mkdir -p build
 cp -vf ./logback-android/build/outputs/aar/logback-android*.aar ./build/


### PR DESCRIPTION
Fourth round of issue triage — six more open issues addressed, including the two oldest pinned ones' close relative (#65 from 2014).

## Socket appender: background host resolution + `lazy` (fixes #65, fixes #341)

`AbstractSocketAppender` resolved the remote host with `InetAddress.getByName` inside `start()`: a blocking network lookup on whatever thread initializes logging (often the main thread), and a device that was offline at startup failed resolution once and **permanently disabled the appender** — no retry, silent event loss thereafter. Resolution now happens in the background dispatch task, retrying with the configured `reconnectionDelay` until it succeeds — the same policy connection failures already follow.

Also, the wiki has always documented `<lazy>` for `SocketAppender`/`SyslogAppender`, but only `SyslogAppenderBase` implemented it — socket configs failed with `no applicable action for [lazy]` (#341). `AbstractSocketAppender` now supports `lazy`, deferring the dispatch task (and therefore resolution/connection) until the first log event.

Updated `AbstractSocketAppenderTest`: the fail-on-start-with-unresolvable-host test now asserts the new start-and-retry behavior, and a new test covers lazy deferral. All 27 tests pass.

## `${EXT_FILES_DIR}` / `${EXT_CACHE_DIR}` properties (fixes #181) + storage-state hardening (fixes #315)

The app-specific external dirs (`Context#getExternalFilesDir/getExternalCacheDir`) are now exposed as config properties. Unlike `${EXT_DIR}`, they don't change meaning across Android versions (the crux of #223) and are writable without permissions on API 19+ — the right target for log files under scoped storage (also the answer for #228/#366-style configs).

Separately, `Environment.getExternalStorageState()` throws `ArrayIndexOutOfBoundsException` in processes without an external storage volume (shell-context tools launched via `app_process`, per #315) — `getMountedExternalStorageDirectoryPath()` now treats that as "not mounted" instead of crashing logger init.

## `%highlight` and ANSI color converters (fixes #332)

Patterns shared with regular logback that use `%highlight(...)`, `%cyan(...)`, etc. failed with `no conversion class registered for composite conversion word` because the color converters were dropped from this port. Added the full set (`black`…`white`, `gray`, `bold*` variants, level-based `%highlight`) under `ch.qos.logback.core.pattern.color` and registered them in `PatternLayout`. Verified output matches upstream exactly (ERROR→`1;31`, WARN→`31`, INFO→`34`, else `39`). Logcat viewers don't render ANSI, so this is primarily config parity — documented as such.

## `makejar.sh` (fixes #346)

The script sourced `gradle.properties` **as shell**, so `org.gradle.jvmargs=-Xmx6g` failed with "command not found" — and since the `#!/usr/bin/env bash -e` shebang silently drops `-e` on Linux, it barreled on with an empty version. Now extracts `VERSION_NAME` with `sed`, fails fast if missing, uses a proper `set -e`, and `mkdir -p`.

## Verification

Standalone against Robolectric's `android-all` jar (Gradle/AGP unavailable in this sandbox): all 411 main sources compile; `AbstractSocketAppenderTest` (27), `CompressorDurabilityTest`, and `TimeBasedRollingTest` pass (43 total); a scratch harness confirms the reporter's exact `%highlight(%-5level) %cyan(%logger{36})` pattern compiles error-free with upstream-identical ANSI output; the Robolectric-only tests (`AndroidContextUtilTest`, `PatternLayoutTest` additions) compile and run in CI. `makejar.sh` passes `bash -n` and the version extraction was exercised against the real `gradle.properties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_