### PR TITLE
fix: resolve socket appender host in background and add lazy option

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/net/AbstractSocketAppender.java
@@ -85,10 +85,13 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   private int acceptConnectionTimeout = DEFAULT_ACCEPT_CONNECTION_DELAY;
   private Duration eventDelayLimit = new Duration(DEFAULT_EVENT_DELAY_TIMEOUT);
   
+  private boolean lazyInit = false;
+
   private BlockingDeque<E> deque;
   private String peerId;
   private SocketConnector connector;
   private Future<?> task;
+  private boolean taskSubmitted = false;
 
   private volatile Socket socket;
 
@@ -137,25 +140,25 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
     }
 
     if (errorCount == 0) {
-      try {
-        address = InetAddress.getByName(remoteHost);
-      } catch (UnknownHostException ex) {
-        addError("unknown host: " + remoteHost);
-        errorCount++;
-      }
-    }
-
-    if (errorCount == 0) {
       deque = queueFactory.newLinkedBlockingDeque(queueSize);
       peerId = "remote peer " + remoteHost + ":" + port + ": ";
-      connector = createConnector(address, port, 0, reconnectionDelay.getMilliseconds());
-      task = getContext().getScheduledExecutorService().submit(new Runnable() {
-        public void run() {
-          connectSocketAndDispatchEvents();
-        }
-      });
+      // defer the dispatch task (and the host-name resolution it performs)
+      // until the first log event when lazy (issue #341)
+      if (!lazyInit) {
+        submitDispatchTask();
+      }
       super.start();
     }
+  }
+
+  private synchronized void submitDispatchTask() {
+    if (taskSubmitted) return;
+    taskSubmitted = true;
+    task = getContext().getScheduledExecutorService().submit(new Runnable() {
+      public void run() {
+        resolveHostAndDispatchEvents();
+      }
+    });
   }
 
   /**
@@ -165,7 +168,9 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   public void stop() {
     if (!isStarted()) return;
     CloseUtil.closeQuietly(socket);
-    task.cancel(true);
+    if (task != null) {
+      task.cancel(true);
+    }
     super.stop();
   }
 
@@ -175,6 +180,7 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
   @Override
   protected void append(E event) {
     if (event == null || !isStarted()) return;
+    submitDispatchTask();
 
     try {
       final boolean inserted = deque.offer(event, eventDelayLimit.getMilliseconds(), TimeUnit.MILLISECONDS);
@@ -183,6 +189,39 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
       }
     } catch (InterruptedException e) {
       addError("Interrupted while appending event to SocketAppender", e);
+    }
+  }
+
+  private void resolveHostAndDispatchEvents() {
+    // Resolve the host name in the background task rather than in start()
+    // (issue #65): resolution does a network lookup, which must not run on
+    // the thread that initializes logging (often the main thread), and a
+    // device that is offline at startup would otherwise permanently disable
+    // this appender. Retry with the reconnection delay until resolved.
+    try {
+      while (!resolveRemoteHost()) {
+        long delayMs = (reconnectionDelay != null) ? reconnectionDelay.getMilliseconds() : 0;
+        if (delayMs <= 0) {
+          addError(peerId + "gave up resolving host (reconnectionDelay is zero)");
+          return;
+        }
+        Thread.sleep(delayMs);
+      }
+    } catch (InterruptedException ex) {
+      addInfo("shutting down before host resolution completed");
+      return;
+    }
+    connector = createConnector(address, port, 0, reconnectionDelay.getMilliseconds());
+    connectSocketAndDispatchEvents();
+  }
+
+  private boolean resolveRemoteHost() {
+    try {
+      address = InetAddress.getByName(remoteHost);
+      return true;
+    } catch (UnknownHostException ex) {
+      addWarn(peerId + "unknown host: " + remoteHost + " (will retry)");
+      return false;
     }
   }
 
@@ -303,6 +342,26 @@ public abstract class AbstractSocketAppender<E> extends AppenderBase<E>
    * @return transformer object
    */
   protected abstract PreSerializationTransformer<E> getPST();
+
+  /**
+   * Gets the enable status of lazy initialization of the socket connection
+   *
+   * @return true if enabled; false otherwise
+   */
+  public boolean getLazy() {
+    return lazyInit;
+  }
+
+  /**
+   * Enables/disables lazy initialization of the socket connection. This
+   * defers the host-name resolution and connection until the first
+   * outgoing message (issue #341).
+   *
+   * @param enable true to enable lazy initialization; false otherwise
+   */
+  public void setLazy(boolean enable) {
+    lazyInit = enable;
+  }
 
   /**
    * The <b>RemoteHost</b> property takes the name of of the host where a corresponding server is running.

--- a/logback-android/src/test/java/ch/qos/logback/core/net/AbstractSocketAppenderTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/net/AbstractSocketAppenderTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
@@ -159,8 +160,11 @@ public class AbstractSocketAppenderTest {
     verify(appender).addError(contains("Queue size must be greater than zero"));
   }
 
+  // Issue #65: host-name resolution happens in the background task with
+  // retries, so an unresolvable host (e.g. device offline at startup) no
+  // longer prevents the appender from starting
   @Test
-  public void failsToStartWithUnresolvableRemoteHost() throws Exception {
+  public void startsWithUnresolvableRemoteHostAndRetriesResolution() throws Exception {
 
     new NetworkTestUtil().assumeNoUnresolvedUrlFallback();
 
@@ -171,8 +175,31 @@ public class AbstractSocketAppenderTest {
     appender.start();
 
     // then
-    assertFalse(appender.isStarted());
-    verify(appender).addError(contains("unknown host"));
+    assertTrue(appender.isStarted());
+    verify(appender, timeout(TIMEOUT)).addWarn(contains("unknown host"));
+  }
+
+  // Issue #341
+  @Test
+  public void lazyInitDefersConnectionUntilFirstEvent() throws Exception {
+
+    // given
+    mockOneSuccessfulSocketConnection();
+    appender.setLazy(true);
+
+    // when
+    appender.start();
+
+    // then: started, but no connection attempt yet (the dispatch task is
+    // only submitted on the first append, so nothing runs asynchronously)
+    assertTrue(appender.isStarted());
+    verify(appender, never()).newConnector(any(InetAddress.class), anyInt(), anyLong(), anyLong());
+
+    // when
+    appender.append("some event");
+
+    // then
+    verify(appender, timeout(TIMEOUT)).newConnector(any(InetAddress.class), anyInt(), anyLong(), anyLong());
   }
 
   @Test


### PR DESCRIPTION
Split from #428 (one fix per PR).

`AbstractSocketAppender` resolved the remote host with `InetAddress.getByName` inside `start()`: a blocking network lookup on whatever thread initializes logging (often the main thread), and a device that was offline at startup failed resolution once and **permanently disabled the appender** — no retry, silent event loss thereafter (#65, reported in 2014). Resolution now happens in the background dispatch task, retrying with the configured `reconnectionDelay` until it succeeds — the same policy connection failures already follow.

Also, the wiki has always documented `<lazy>` for `SocketAppender`/`SyslogAppender`, but only `SyslogAppenderBase` implemented it — socket configs failed with `no applicable action for [lazy]` (#341). `AbstractSocketAppender` now supports `lazy`, deferring the dispatch task (and therefore resolution/connection) until the first log event. The `<lazy>` element already exists in the XML schema.

Behavior change: a config with an unresolvable host now starts and retries in the background (warning status per attempt) instead of failing `start()` — consistent with how connection failures behave.

**Tests:** the fail-on-start-with-unresolvable-host test now asserts the new start-and-retry behavior, and a new test covers lazy deferral. All 27 `AbstractSocketAppenderTest` tests pass (run standalone against Robolectric's `android-all` jar; CI runs the full suite).

Fixes #65
Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_