### PR TITLE
feat: add EXT_FILES_DIR and EXT_CACHE_DIR config properties

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/CoreConstants.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/CoreConstants.java
@@ -179,6 +179,25 @@ public class CoreConstants {
   public static final String EXT_DIR_KEY = "EXT_DIR";
 
   /**
+   * The key under which the application's external files directory
+   * (i.e. {@code Context#getExternalFilesDir(null)}) is registered in the
+   * logger context. Unlike {@link #EXT_DIR_KEY}, this value does not depend
+   * on the Android version. The value is typically something like:
+   * "/storage/emulated/0/Android/data/com.example/files" and is absent when
+   * external storage is unavailable.
+   */
+  public static final String EXT_FILES_DIR_KEY = "EXT_FILES_DIR";
+
+  /**
+   * The key under which the application's external cache directory
+   * (i.e. {@code Context#getExternalCacheDir()}) is registered in the
+   * logger context. The value is typically something like:
+   * "/storage/emulated/0/Android/data/com.example/cache" and is absent when
+   * external storage is unavailable.
+   */
+  public static final String EXT_CACHE_DIR_KEY = "EXT_CACHE_DIR";
+
+  /**
    * The key under which the application package name is registered
    * in the logger context.
    */

--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -52,6 +52,8 @@ public class AndroidContextUtil {
   public static boolean containsProperties(String value) {
     return value.contains(CoreConstants.DATA_DIR_KEY)
             || value.contains(CoreConstants.EXT_DIR_KEY)
+            || value.contains(CoreConstants.EXT_FILES_DIR_KEY)
+            || value.contains(CoreConstants.EXT_CACHE_DIR_KEY)
             || value.contains(CoreConstants.PACKAGE_NAME_KEY)
             || value.contains(CoreConstants.VERSION_CODE_KEY)
             || value.contains(CoreConstants.VERSION_NAME_KEY);
@@ -67,6 +69,16 @@ public class AndroidContextUtil {
     final String extDir = getMountedExternalStorageDirectoryPath();
     if (extDir != null) {
       context.putProperty(CoreConstants.EXT_DIR_KEY, extDir);
+    }
+    // Android-version-independent paths to the app-specific external
+    // directories, writable without permissions on API 19+ (issue #181)
+    final String extFilesDir = getExternalFilesDirectoryPath();
+    if (extFilesDir != null && !extFilesDir.isEmpty()) {
+      context.putProperty(CoreConstants.EXT_FILES_DIR_KEY, extFilesDir);
+    }
+    final String extCacheDir = getExternalCacheDirectoryPath();
+    if (extCacheDir != null && !extCacheDir.isEmpty()) {
+      context.putProperty(CoreConstants.EXT_CACHE_DIR_KEY, extCacheDir);
     }
     context.putProperty(CoreConstants.PACKAGE_NAME_KEY, getPackageName());
     context.putProperty(CoreConstants.VERSION_CODE_KEY, getVersionCode());

--- a/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
@@ -205,4 +205,26 @@ public class AndroidContextUtilTest {
     assertThat(loggerContext.getProperty(CoreConstants.VERSION_NAME_KEY), is(contextUtil.getVersionName()));
     assertThat(loggerContext.getProperty(CoreConstants.PACKAGE_NAME_KEY), is(contextUtil.getPackageName()));
   }
+
+  // Issue #181
+  @Test
+  public void setupPropertiesIncludesExternalDirs() {
+    LoggerContext loggerContext = new LoggerContext();
+
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_FILES_DIR_KEY), is(nullValue()));
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_CACHE_DIR_KEY), is(nullValue()));
+
+    contextUtil.setupProperties(loggerContext);
+
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_FILES_DIR_KEY), is(contextUtil.getExternalFilesDirectoryPath()));
+    assertThat(loggerContext.getProperty(CoreConstants.EXT_CACHE_DIR_KEY), is(contextUtil.getExternalCacheDirectoryPath()));
+  }
+
+  // Issue #181
+  @Test
+  public void containsPropertiesDetectsExternalDirKeys() {
+    assertThat(AndroidContextUtil.containsProperties("${EXT_FILES_DIR}/logs/app.log"), is(true));
+    assertThat(AndroidContextUtil.containsProperties("${EXT_CACHE_DIR}/logs/app.log"), is(true));
+    assertThat(AndroidContextUtil.containsProperties("/absolute/path/app.log"), is(false));
+  }
 }


### PR DESCRIPTION
Split from #428 (one fix per PR).

Exposes the app-specific external directories as config properties: `${EXT_FILES_DIR}` (`Context#getExternalFilesDir(null)`) and `${EXT_CACHE_DIR}` (`Context#getExternalCacheDir()`). Unlike `${EXT_DIR}`, these don't change meaning across Android versions (the crux of #223) and are writable without permissions on API 19+ — the right target for log files under scoped storage (also the recommended path for #228/#366-style configs).

The properties participate in the same lazy setup as the existing ones (`containsProperties`/`setupProperties`), and are only set when the corresponding directory is available.

**Tests:** `AndroidContextUtilTest` gains coverage that `setupProperties` publishes both properties and that `containsProperties` detects them (Robolectric; runs in CI).

Fixes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_