### PR TITLE
fix: tolerate broken external-storage state during logger init

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -119,7 +119,16 @@ public class AndroidContextUtil {
    */
   public String getMountedExternalStorageDirectoryPath() {
     String path = null;
-    String state = Environment.getExternalStorageState();
+    String state;
+    try {
+      state = Environment.getExternalStorageState();
+    } catch (RuntimeException e) {
+      // Environment.getExternalStorageState throws
+      // ArrayIndexOutOfBoundsException in processes without an external
+      // storage volume, e.g. shell-context tools started via app_process
+      // (issue #315); treat it the same as "not mounted"
+      return null;
+    }
     if (Environment.MEDIA_MOUNTED.equals(state) ||
         Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
       path = getExternalStorageDirectoryPath();


### PR DESCRIPTION
Split from #428 (one fix per PR).

`Environment.getExternalStorageState()` throws `ArrayIndexOutOfBoundsException` in processes that have no external-storage volume — the situation for shell-context tools like minicap launched via `app_process` rather than as a regular app — which crashed logger initialization (#315). `getMountedExternalStorageDirectoryPath()` now catches the failure and behaves as if external storage simply isn't mounted: initialization proceeds and the `EXT_DIR` property just isn't set.

One-hunk change; the crash requires a volume-less process context, which isn't reproducible under Robolectric, so no new unit test — CI verifies no regressions in the existing `AndroidContextUtilTest` storage-state matrix.

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_