### PR TITLE
feat: support %highlight and ANSI color pattern converters

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/classic/PatternLayout.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/PatternLayout.java
@@ -19,9 +19,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import ch.qos.logback.classic.pattern.*;
+import ch.qos.logback.classic.pattern.color.HighlightingCompositeConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.pattern.PatternLayoutBase;
+import ch.qos.logback.core.pattern.color.*;
 import ch.qos.logback.core.pattern.parser.Parser;
 
 /**
@@ -110,6 +112,27 @@ public class PatternLayout extends PatternLayoutBase<ILoggingEvent> {
     defaultConverterMap.put("n", LineSeparatorConverter.class.getName());
 
     defaultConverterMap.put("lsn", LocalSequenceNumberConverter.class.getName());
+
+    // ANSI color composite converters (issue #332); mainly for parity with
+    // configurations shared with regular logback, since logcat viewers do
+    // not render ANSI escape codes
+    defaultConverterMap.put("black", BlackCompositeConverter.class.getName());
+    defaultConverterMap.put("red", RedCompositeConverter.class.getName());
+    defaultConverterMap.put("green", GreenCompositeConverter.class.getName());
+    defaultConverterMap.put("yellow", YellowCompositeConverter.class.getName());
+    defaultConverterMap.put("blue", BlueCompositeConverter.class.getName());
+    defaultConverterMap.put("magenta", MagentaCompositeConverter.class.getName());
+    defaultConverterMap.put("cyan", CyanCompositeConverter.class.getName());
+    defaultConverterMap.put("white", WhiteCompositeConverter.class.getName());
+    defaultConverterMap.put("gray", GrayCompositeConverter.class.getName());
+    defaultConverterMap.put("boldRed", BoldRedCompositeConverter.class.getName());
+    defaultConverterMap.put("boldGreen", BoldGreenCompositeConverter.class.getName());
+    defaultConverterMap.put("boldYellow", BoldYellowCompositeConverter.class.getName());
+    defaultConverterMap.put("boldBlue", BoldBlueCompositeConverter.class.getName());
+    defaultConverterMap.put("boldMagenta", BoldMagentaCompositeConverter.class.getName());
+    defaultConverterMap.put("boldCyan", BoldCyanCompositeConverter.class.getName());
+    defaultConverterMap.put("boldWhite", BoldWhiteCompositeConverter.class.getName());
+    defaultConverterMap.put("highlight", HighlightingCompositeConverter.class.getName());
   }
 
   public PatternLayout() {

--- a/logback-android/src/main/java/ch/qos/logback/classic/pattern/color/HighlightingCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/classic/pattern/color/HighlightingCompositeConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.classic.pattern.color;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.color.ANSIConstants;
+import ch.qos.logback.core.pattern.color.ForegroundCompositeConverterBase;
+
+/**
+ * Colors the child output according to the event's level: bold red for
+ * ERROR, red for WARN, blue for INFO, and the default color otherwise
+ * (issue #332). Used via {@code %highlight(...)}.
+ */
+public class HighlightingCompositeConverter extends ForegroundCompositeConverterBase<ILoggingEvent> {
+
+  @Override
+  protected String getForegroundColorCode(ILoggingEvent event) {
+    Level level = event.getLevel();
+    switch (level.toInt()) {
+      case Level.ERROR_INT:
+        return ANSIConstants.BOLD + ANSIConstants.RED_FG;
+      case Level.WARN_INT:
+        return ANSIConstants.RED_FG;
+      case Level.INFO_INT:
+        return ANSIConstants.BLUE_FG;
+      default:
+        return ANSIConstants.DEFAULT_FG;
+    }
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ANSIConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * ANSI escape codes used by the color composite converters (issue #332)
+ */
+public class ANSIConstants {
+
+  public final static String ESC_START = "\033[";
+  public final static String ESC_END = "m";
+
+  public final static String BOLD = "1;";
+
+  public final static String BLACK_FG = "30";
+  public final static String RED_FG = "31";
+  public final static String GREEN_FG = "32";
+  public final static String YELLOW_FG = "33";
+  public final static String BLUE_FG = "34";
+  public final static String MAGENTA_FG = "35";
+  public final static String CYAN_FG = "36";
+  public final static String WHITE_FG = "37";
+  public final static String DEFAULT_FG = "39";
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlackCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlackCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a black foreground.
+ *
+ * @param <E> the event type
+ */
+public class BlackCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BLACK_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlueCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BlueCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a blue foreground.
+ *
+ * @param <E> the event type
+ */
+public class BlueCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BLUE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldBlueCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldBlueCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldBlue foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldBlueCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.BLUE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldCyanCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldCyanCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldCyan foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldCyanCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.CYAN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldGreenCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldGreenCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldGreen foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldGreenCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.GREEN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldMagentaCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldMagentaCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldMagenta foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldMagentaCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.MAGENTA_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldRedCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldRedCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldRed foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldRedCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.RED_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldWhiteCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldWhiteCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldWhite foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldWhiteCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.WHITE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldYellowCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/BoldYellowCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a boldYellow foreground.
+ *
+ * @param <E> the event type
+ */
+public class BoldYellowCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.YELLOW_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/CyanCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/CyanCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a cyan foreground.
+ *
+ * @param <E> the event type
+ */
+public class CyanCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.CYAN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/ForegroundCompositeConverterBase.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+import ch.qos.logback.core.pattern.CompositeConverter;
+
+/**
+ * Base class for composite converters that wrap their child output in ANSI
+ * foreground-color escape codes, e.g. {@code %cyan(%logger)} (issue #332).
+ * Note that Android's logcat viewers generally do not render ANSI codes;
+ * these converters exist mainly so configurations shared with regular
+ * logback (where consoles do render them) work without errors.
+ *
+ * @param <E> the event type
+ */
+abstract public class ForegroundCompositeConverterBase<E> extends CompositeConverter<E> {
+
+  private final static String SET_DEFAULT_COLOR =
+          ANSIConstants.ESC_START + "0;" + ANSIConstants.DEFAULT_FG + ANSIConstants.ESC_END;
+
+  @Override
+  protected String transform(E event, String in) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(ANSIConstants.ESC_START);
+    sb.append(getForegroundColorCode(event));
+    sb.append(ANSIConstants.ESC_END);
+    sb.append(in);
+    sb.append(SET_DEFAULT_COLOR);
+    return sb.toString();
+  }
+
+  /**
+   * Derives the ANSI foreground color code to use for the given event
+   *
+   * @param event the event being rendered
+   * @return an ANSI foreground color code from {@link ANSIConstants}
+   */
+  abstract protected String getForegroundColorCode(E event);
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GrayCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GrayCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a gray foreground.
+ *
+ * @param <E> the event type
+ */
+public class GrayCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.BOLD + ANSIConstants.BLACK_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GreenCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/GreenCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a green foreground.
+ *
+ * @param <E> the event type
+ */
+public class GreenCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.GREEN_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/MagentaCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/MagentaCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a magenta foreground.
+ *
+ * @param <E> the event type
+ */
+public class MagentaCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.MAGENTA_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/RedCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/RedCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a red foreground.
+ *
+ * @param <E> the event type
+ */
+public class RedCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.RED_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/WhiteCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/WhiteCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a white foreground.
+ *
+ * @param <E> the event type
+ */
+public class WhiteCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.WHITE_FG;
+  }
+}

--- a/logback-android/src/main/java/ch/qos/logback/core/pattern/color/YellowCompositeConverter.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/pattern/color/YellowCompositeConverter.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.pattern.color;
+
+/**
+ * Wraps the child output in the ANSI escape codes for a yellow foreground.
+ *
+ * @param <E> the event type
+ */
+public class YellowCompositeConverter<E> extends ForegroundCompositeConverterBase<E> {
+
+  @Override
+  protected String getForegroundColorCode(E event) {
+    return ANSIConstants.YELLOW_FG;
+  }
+}

--- a/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
@@ -109,7 +109,7 @@ public class PatternLayoutTest extends AbstractPatternLayoutBaseTest<ILoggingEve
     // no "conversion words" errors, and ANSI codes wrap the colored parts;
     // INFO highlights as blue (34), %cyan is 36
     assertThat(val, containsString("\033[34mINFO \033[0;39m"));
-    assertThat(val, containsString("\033[36mc.q.l.c.pattern.ConverterTest\033[0;39m"));
+    assertThat(val, containsString("\033[36mc.q.l.classic.pattern.ConverterTest\033[0;39m"));
     assertThat(val, containsString("Some message"));
   }
 

--- a/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/PatternLayoutTest.java
@@ -98,6 +98,21 @@ public class PatternLayoutTest extends AbstractPatternLayoutBaseTest<ILoggingEve
     assertThat(val, containsString("java.lang.Exception: Bogus exception"));
   }
 
+  // Issue #332: color composite converters must be registered so patterns
+  // shared with regular logback compile without errors
+  @Test
+  public void colorConvertersAreRegistered() {
+    pl.setPattern("%highlight(%-5level) %cyan(%logger{36}) - %msg");
+    pl.start();
+    String val = pl.doLayout(makeLoggingEvent("Some message", null));
+
+    // no "conversion words" errors, and ANSI codes wrap the colored parts;
+    // INFO highlights as blue (34), %cyan is 36
+    assertThat(val, containsString("\033[34mINFO \033[0;39m"));
+    assertThat(val, containsString("\033[36mc.q.l.c.pattern.ConverterTest\033[0;39m"));
+    assertThat(val, containsString("Some message"));
+  }
+
   @Test
   public void testCompositePattern() {
     pl.setPattern("%-56(%d %lo{20}) - %m%n");


### PR DESCRIPTION
Split from #428 (one fix per PR).

Patterns shared with regular logback that use `%highlight(...)`, `%cyan(...)`, etc. failed with `no conversion class registered for composite conversion word` because the color converters were dropped from this port (#332). This adds the ANSI foreground color composite converters under `ch.qos.logback.core.pattern.color` (`black`…`white`, `gray`, the `bold*` variants, and the level-based `%highlight` in `classic`) and registers them in `PatternLayout`.

Output verified byte-identical to upstream logback: ERROR → `1;31` (bold red), WARN → `31`, INFO → `34` (blue), other levels → `39` (default); `%cyan` → `36`.

Expectation-setting (also noted on the issue): logcat viewers don't render ANSI escape codes, so on-device the sequences appear literally — the win is that configurations shared between Android and JVM projects now compile and run unmodified.

**Tests:** new `PatternLayoutTest#colorConvertersAreRegistered` exercises the reporter's exact pattern shape (`%highlight(%-5level) %cyan(%logger{36})`) and asserts the ANSI-wrapped output. Includes the follow-up fix for the expected `%logger{36}` abbreviation caught by CI on #428 (`c.q.l.classic.pattern.ConverterTest`, not the `%lo{30}` form).

Fixes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD28c26fMeRWhJNWyNWk5Q)_