### PR TITLE
test: verify #383 StrictMode DiskReadViolation fix (lazy Android props)

### DIFF
--- a/logback-android/src/test/java/ch/qos/logback/classic/issue/issue383/Issue383StrictModeTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/issue/issue383/Issue383StrictModeTest.java
@@ -59,6 +59,8 @@ import static org.hamcrest.Matchers.is;
 @RunWith(RobolectricTestRunner.class)
 public class Issue383StrictModeTest {
 
+  private FilesDirCountingContext trackingContext;
+
   /**
    * Wraps the real application context and counts every {@link #getFilesDir()}
    * call. On a real device with StrictMode's {@code detectDiskReads()}, each of
@@ -86,8 +88,6 @@ public class Issue383StrictModeTest {
       return super.getFilesDir();
     }
   }
-
-  private FilesDirCountingContext trackingContext;
 
   @Before
   public void setUp() {

--- a/logback-android/src/test/java/ch/qos/logback/classic/issue/issue383/Issue383StrictModeTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/classic/issue/issue383/Issue383StrictModeTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2019 Anthony Trinh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.classic.issue.issue383;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.android.AndroidContextUtil;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Reproduces the scenario from issue #383, where initializing logback through
+ * the slf4j API on Android with StrictMode enabled crashed with a
+ * {@code DiskReadViolation}. In logback-android 2.0.0, configuration eagerly
+ * called {@link AndroidContextUtil#setupProperties(ch.qos.logback.core.Context)},
+ * which invokes {@link Context#getFilesDir()} on the calling (main) thread even
+ * when no config value referenced {@code ${DATA_DIR}}.
+ *
+ * <p>Since 3.0.0, those Android properties are resolved lazily: the disk-touching
+ * {@code getFilesDir()} is only reached when a config value actually references
+ * one of the Android special vars (e.g. {@code ${DATA_DIR}}). This test verifies
+ * that behavior directly, standing in for a manual "logback-test-app" repro so it
+ * does not have to be reproduced by hand on a device.
+ *
+ * @see <a href="https://github.com/tony19/logback-android/issues/383">Issue #383</a>
+ */
+@RunWith(RobolectricTestRunner.class)
+public class Issue383StrictModeTest {
+
+  /**
+   * Wraps the real application context and counts every {@link #getFilesDir()}
+   * call. On a real device with StrictMode's {@code detectDiskReads()}, each of
+   * these calls is what triggers the {@code DiskReadViolation} seen in #383.
+   *
+   * <p>{@link #getApplicationContext()} returns {@code this} so that the counting
+   * wrapper survives {@link AndroidContextUtil}'s internal
+   * {@code context.getApplicationContext()} unwrapping.
+   */
+  private static class FilesDirCountingContext extends ContextWrapper {
+    final AtomicInteger getFilesDirCalls = new AtomicInteger(0);
+
+    FilesDirCountingContext(Context base) {
+      super(base);
+    }
+
+    @Override
+    public Context getApplicationContext() {
+      return this;
+    }
+
+    @Override
+    public File getFilesDir() {
+      getFilesDirCalls.incrementAndGet();
+      return super.getFilesDir();
+    }
+  }
+
+  private FilesDirCountingContext trackingContext;
+
+  @Before
+  public void setUp() {
+    trackingContext = new FilesDirCountingContext(RuntimeEnvironment.getApplication());
+    AndroidContextUtil.setApplicationContext(trackingContext);
+  }
+
+  @After
+  public void tearDown() {
+    AndroidContextUtil.setApplicationContext(null);
+  }
+
+  private static void configure(LoggerContext loggerContext, String xml) throws JoranException {
+    JoranConfigurator jc = new JoranConfigurator();
+    jc.setContext(loggerContext);
+    jc.doConfigure(new ByteArrayInputStream(xml.getBytes(Charset.forName("UTF-8"))));
+  }
+
+  /**
+   * The #383 case: a plain config (no {@code ${DATA_DIR}} reference), just like
+   * the default/no-config slf4j initialization the reporter hit. Configuration
+   * must NOT touch {@link Context#getFilesDir()}, so StrictMode would not flag a
+   * disk read.
+   */
+  @Test
+  public void plainConfigDoesNotTouchGetFilesDir() throws JoranException {
+    String xml =
+        "<configuration>" +
+        "  <appender name='CONSOLE' class='ch.qos.logback.core.ConsoleAppender'>" +
+        "    <encoder><pattern>%msg%n</pattern></encoder>" +
+        "  </appender>" +
+        "  <root level='DEBUG'><appender-ref ref='CONSOLE'/></root>" +
+        "</configuration>";
+
+    LoggerContext loggerContext = new LoggerContext();
+    configure(loggerContext, xml);
+
+    assertThat("plain configuration must not call Context.getFilesDir() (issue #383)",
+        trackingContext.getFilesDirCalls.get(), is(0));
+    // The Android property is never resolved, so it stays unset.
+    assertThat(loggerContext.getProperty(CoreConstants.DATA_DIR_KEY), is((String) null));
+  }
+
+  /**
+   * When a config value genuinely references {@code ${DATA_DIR}}, the disk access
+   * is inherent (the property has to be resolved). This confirms the lazy path
+   * still works: {@code getFilesDir()} is reached, and {@code ${DATA_DIR}} resolves
+   * to the real files dir.
+   */
+  @Test
+  public void configReferencingDataDirResolvesLazily() throws JoranException {
+    String xml =
+        "<configuration>" +
+        "  <property name='LOG_DIR' value='${DATA_DIR}/logs' />" +
+        "  <appender name='CONSOLE' class='ch.qos.logback.core.ConsoleAppender'>" +
+        "    <encoder><pattern>${LOG_DIR} %msg%n</pattern></encoder>" +
+        "  </appender>" +
+        "  <root level='DEBUG'><appender-ref ref='CONSOLE'/></root>" +
+        "</configuration>";
+
+    LoggerContext loggerContext = new LoggerContext();
+    configure(loggerContext, xml);
+
+    assertThat("a config referencing ${DATA_DIR} must resolve it (and thus touch getFilesDir())",
+        trackingContext.getFilesDirCalls.get(), is(greaterThanOrEqualTo(1)));
+    assertThat(loggerContext.getProperty(CoreConstants.DATA_DIR_KEY),
+        is(trackingContext.getFilesDir().getAbsolutePath()));
+  }
+}


### PR DESCRIPTION
## Summary

Issue #383 reports a `DiskReadViolation` crash when logback-android 2.0.0 is initialized through the slf4j API with StrictMode's `detectDiskReads()` enabled. The stack trace shows `ContextInitializer.autoConfig()` eagerly calling `AndroidContextUtil.setupProperties()`, which invokes `Context.getFilesDir()` on the calling (main) thread.

This PR **verifies that the issue is already fixed on the 3.0.x line** and adds a regression test so it stays fixed — rather than asking the reporter to confirm.

## What was verified

In 3.0.x the Android properties (`DATA_DIR`, `EXT_DIR`, `PACKAGE_NAME`, `VERSION_*`, …) are resolved **lazily**:

- `ContextInitializer.autoConfig()` no longer calls `setupProperties()` at all — both init paths (`StaticLoggerBinder` and the slf4j-2.x `LoggerServiceProvider`) go through it.
- `setupProperties()` (the method that touches `getFilesDir()`) is only invoked from `InterpretationContext.subst()` → `initAndroidContextIfValueHasSpecialVars()`, and only when a config value actually contains one of the Android special vars (gated by `AndroidContextUtil.containsProperties(value)`).

So plain slf4j initialization — including the default/no-config case in the bug report — never touches `getFilesDir()`, and StrictMode has nothing to flag.

## The test

`Issue383StrictModeTest` (Robolectric) reproduces the reporter's setup with a counting `ContextWrapper` and asserts:

1. **Plain config** (no `${DATA_DIR}` reference) → `getFilesDir()` is called **0** times, and `DATA_DIR` stays unset. This is the #383 case.
2. **Config referencing `${DATA_DIR}`** → `getFilesDir()` is reached lazily and `${DATA_DIR}` resolves to the real files dir, confirming the property path still works when genuinely needed.

## Notes for the reporter

- Upgrading 2.x → 3.0.x also moves to slf4j 2.x (`SLF4JServiceProvider` instead of `StaticLoggerBinder`), so `org.slf4j:slf4j-api` must be 2.x as well.
- If a `logback.xml` *does* reference `${DATA_DIR}` (e.g. a `FileAppender`), the disk access is inherent to opening that file during configuration; trigger the first `LoggerFactory.getLogger(...)` from a background thread at startup to keep it off the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGfUAhqpA8dAjz1NCTYJS4)_