### PR TITLE
fix: create app-specific external dirs via platform when mkdirs fails

### DIFF
--- a/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/android/AndroidContextUtil.java
@@ -184,6 +184,33 @@ public class AndroidContextUtil {
             : "";
   }
 
+  /**
+   * Requests creation of the app-specific external storage directories
+   * ({@code Android/data/<package>/files} and {@code Android/data/<package>/cache}).
+   *
+   * Under scoped storage (Android 11+), these base directories can only be
+   * created by the platform: a plain {@link File#mkdirs()} fails until the
+   * app requests them via
+   * {@link android.content.Context#getExternalFilesDir(String)} or
+   * {@link android.content.Context#getExternalCacheDir()}, both of which
+   * create the directory if it doesn't already exist (issue #228).
+   *
+   * This is a no-op if no Android context is available, and it tolerates
+   * broken external-storage states (issue #431).
+   */
+  public void createAppExternalStorageDirs() {
+    if (this.context == null) {
+      return;
+    }
+    try {
+      this.context.getExternalFilesDir(null);
+      this.context.getExternalCacheDir();
+    } catch (RuntimeException e) {
+      // tolerate broken external-storage state (issue #431); the caller's
+      // subsequent directory-creation attempt fails and reports as usual
+    }
+  }
+
   public String getCacheDirectoryPath() {
     return this.context != null
             ? absPath(this.context.getCacheDir())

--- a/logback-android/src/main/java/ch/qos/logback/core/util/FileUtil.java
+++ b/logback-android/src/main/java/ch/qos/logback/core/util/FileUtil.java
@@ -17,6 +17,7 @@ package ch.qos.logback.core.util;
 
 import java.io.File;
 import ch.qos.logback.core.Context;
+import ch.qos.logback.core.android.AndroidContextUtil;
 import ch.qos.logback.core.rolling.RolloverFailure;
 import ch.qos.logback.core.spi.ContextAwareBase;
 
@@ -38,6 +39,11 @@ public class FileUtil extends ContextAwareBase {
    * parent directories were created successfully; {@code false} otherwise
    */
   static public boolean createMissingParentDirectories(File file) {
+    return createMissingParentDirectories(file, null);
+  }
+
+  // package-private for testing
+  static boolean createMissingParentDirectories(File file, AndroidContextUtil androidContextUtil) {
     File parent = file.getParentFile();
     if (parent == null) {
       // Parent directory not specified, therefore it's a request to
@@ -47,6 +53,18 @@ public class FileUtil extends ContextAwareBase {
     // File.mkdirs() creates the parent directories only if they don't
     // already exist; and it's okay if they do.
     parent.mkdirs();
+    if (!parent.exists()) {
+      // Under scoped storage (Android 11+), the app-specific external
+      // directories (Android/data/<package>/{files,cache}) can only be
+      // created by the platform, so mkdirs() fails for paths beneath them
+      // until the app requests those base directories from the OS.
+      // Request them now, then retry (issue #228).
+      if (androidContextUtil == null) {
+        androidContextUtil = new AndroidContextUtil();
+      }
+      androidContextUtil.createAppExternalStorageDirs();
+      parent.mkdirs();
+    }
     return parent.exists();
   }
 

--- a/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/android/AndroidContextUtilTest.java
@@ -220,6 +220,29 @@ public class AndroidContextUtilTest {
     assertThat(loggerContext.getProperty(CoreConstants.EXT_CACHE_DIR_KEY), is(contextUtil.getExternalCacheDirectoryPath()));
   }
 
+  // Issue #228
+  @Test
+  public void createAppExternalStorageDirsCreatesMissingDirs() {
+    android.content.Context appContext = RuntimeEnvironment.getApplication();
+    java.io.File extFilesDir = appContext.getExternalFilesDir(null);
+    java.io.File extCacheDir = appContext.getExternalCacheDir();
+
+    assertThat(extFilesDir.delete(), is(true));
+    assertThat(extCacheDir.delete(), is(true));
+
+    contextUtil.createAppExternalStorageDirs();
+
+    assertThat(extFilesDir.exists(), is(true));
+    assertThat(extCacheDir.exists(), is(true));
+  }
+
+  // Issue #228
+  @Test
+  public void createAppExternalStorageDirsIsNoopWithoutContext() {
+    // must not throw
+    new AndroidContextUtil(null).createAppExternalStorageDirs();
+  }
+
   // Issue #181
   @Test
   public void containsPropertiesDetectsExternalDirKeys() {

--- a/logback-android/src/test/java/ch/qos/logback/core/util/FileUtilTest.java
+++ b/logback-android/src/test/java/ch/qos/logback/core/util/FileUtilTest.java
@@ -27,6 +27,7 @@ import java.util.Random;
 
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.android.AndroidContextUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -105,5 +106,54 @@ public class FileUtilTest {
   public void createParentDirAcceptsNoParentSpecified() {
     File file = new File("testing.txt");
     assertTrue(FileUtil.createMissingParentDirectories(file));
+  }
+
+  // Issue #228: on Android 11+, mkdirs() fails for paths beneath the
+  // app-specific external directories until the platform creates the base
+  // dirs upon the app's request. Verify that when the first mkdirs() fails,
+  // the base directories are requested from AndroidContextUtil and mkdirs()
+  // is retried.
+  @Test
+  public void createParentDirRetriesAfterCreatingAppExternalStorageDirs() throws IOException {
+    // a regular file blocking the parent chain makes the first mkdirs()
+    // fail, standing in for the OS rejecting creation of Android/data dirs
+    final File blocker = new File(CoreTestConstants.OUTPUT_DIR_PREFIX + "/fu" + diff + "/blocker");
+    File file = new File(blocker, "logs/testing.txt");
+    cleanupList.add(file);
+    cleanupList.add(file.getParentFile());
+    cleanupList.add(blocker);
+    cleanupList.add(blocker.getParentFile());
+
+    blocker.getParentFile().mkdirs();
+    assertTrue(blocker.createNewFile());
+
+    AndroidContextUtil platform = new AndroidContextUtil(null) {
+      @Override
+      public void createAppExternalStorageDirs() {
+        // simulate the platform creating the requested base directories
+        blocker.delete();
+        blocker.mkdirs();
+      }
+    };
+
+    assertTrue(FileUtil.createMissingParentDirectories(file, platform));
+    assertTrue(file.getParentFile().exists());
+  }
+
+  // Issue #228
+  @Test
+  public void createParentDirReturnsFalseWhenRetryAlsoFails() throws IOException {
+    File blocker = new File(CoreTestConstants.OUTPUT_DIR_PREFIX + "/fu" + diff + "/blocker2");
+    File file = new File(blocker, "logs/testing.txt");
+    cleanupList.add(blocker);
+    cleanupList.add(blocker.getParentFile());
+
+    blocker.getParentFile().mkdirs();
+    assertTrue(blocker.createNewFile());
+
+    // no-op platform (no Android context available)
+    AndroidContextUtil platform = new AndroidContextUtil(null);
+
+    assertFalse(FileUtil.createMissingParentDirectories(file, platform));
   }
 }


### PR DESCRIPTION
## Summary

Fixes the reproducible part of #228: on Android 11+ (scoped storage), the app-specific external base directories (`Android/data/<package>/files` and `.../cache`) can only be created by the platform — a plain `File#mkdirs()` fails for paths beneath them until the app requests those directories via `Context#getExternalFilesDir(String)` / `Context#getExternalCacheDir()`.

Configs using `${EXT_FILES_DIR}` were unaffected (property resolution performs that platform call), but configs that **hardcode** the absolute path failed to open the log file with:

```
openFile(/storage/emulated/0/Android/data/com.example/files/file.log,true) failed
java.io.FileNotFoundException: ... open failed: ENOENT (No such file or directory)
```

…unless the app happened to call `getExternalFilesDir()` itself first (as noted in https://github.com/tony19/logback-android/issues/228#issuecomment-1322681671).

## Changes

- **`AndroidContextUtil.createAppExternalStorageDirs()`** (new): requests creation of the app-specific external files/cache dirs from the OS; no-op without a context, and tolerates broken external-storage state (same rationale as #431).
- **`FileUtil.createMissingParentDirectories()`**: when the initial `mkdirs()` fails, requests the app's external storage dirs from the platform and retries. `RenameUtil` and `Compressor` (rollover paths) share this helper and inherit the fix.

## Tests

- `FileUtilTest.createParentDirRetriesAfterCreatingAppExternalStorageDirs` — verifies the retry succeeds once the "platform" creates the base dirs
- `FileUtilTest.createParentDirReturnsFalseWhenRetryAlsoFails` — verifies graceful failure when the retry can't help
- `AndroidContextUtilTest.createAppExternalStorageDirsCreatesMissingDirs` — verifies deleted external dirs are recreated on request (Robolectric)
- `AndroidContextUtilTest.createAppExternalStorageDirsIsNoopWithoutContext`

Verified locally (all 4 new tests pass; existing `FileUtilTest`/`AndroidContextUtilTest` tests unaffected). Note: the Gradle distribution host is blocked in this environment, so tests were run through a Maven harness against the same sources; CI should be the authoritative full-suite run.

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud6Md3e4kcaqy36jG2cssZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ud6Md3e4kcaqy36jG2cssZ)_