### PR TITLE
build(deps): bump Android Gradle Plugin to 9.3.0 on JDK 21 only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,17 @@ jobs:
         # made JDK-specific by their compile targets:
         #   logback-android      -> Java 11 bytecode, minSdk 26
         #   logback-android-jdk8 -> Java 8 bytecode, minSdk 21
-        java: [17, 21]
+        #
+        # agp: the Android Gradle Plugin version to build with (overrides the
+        # gradle.properties default). AGP 9.3.0+ lint requires JDK 21, so JDK 17
+        # stays on 9.2.1 while JDK 21 exercises the newer plugin.
+        include:
+          - java: 17
+            agp: '9.2.1'
+          - java: 21
+            agp: '9.3.0'
+    env:
+      ORG_GRADLE_PROJECT_agpVersion: ${{ matrix.agp }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:9.2.1'
+    classpath "com.android.tools.build:gradle:${agpVersion}"
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,6 +13,12 @@ VERSION_CODE=3020000
 
 slf4jVersion=2.0.7
 
+# Android Gradle Plugin version. Defaults to 9.2.1, which still builds under
+# JDK 17. CI overrides this to a newer AGP only on the JDK 21 matrix leg (see
+# ORG_GRADLE_PROJECT_agpVersion in .github/workflows/build.yml): AGP 9.3.0+
+# lint requires JDK 21 (it calls java.util.List.removeLast(), a JDK 21 API).
+agpVersion=9.2.1
+
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750


### PR DESCRIPTION
## Summary

Adopts Android Gradle Plugin **9.3.0**, but only on the JDK 21 build leg — superseding Dependabot's #438, which bumped AGP to 9.3.0 unconditionally and broke the **JDK 17** CI build.

## Why #438 fails

AGP 9.3.0's bundled Android Lint calls `java.util.List.removeLast()` — a method added to `List` in JDK 21 (`SequencedCollection`). Under JDK 17 that method doesn't exist, so `./gradlew lint` crashes:

```
> Task :logback-android:lintAnalyzeJdk11Debug FAILED
  Unexpected failure during lint analysis (this is a bug in lint or one of the libraries it depends on)
  Message: 'java.lang.Object java.util.List.removeLast()'
  ... NoSuchMethodError ... BidirectionalTextDetector
```

`Build (JDK 21)` passed; only `Build (JDK 17)` failed, and only at the `lint` step (assemble, bytecode verification, and unit tests all pass under JDK 17 + AGP 9.3.0).

## Approach

Keep JDK 17 coverage by making the AGP version a Gradle property instead of dropping the JDK 17 matrix leg:

- `build.gradle` — buildscript classpath reads `com.android.tools.build:gradle:${agpVersion}`
- `gradle.properties` — `agpVersion` defaults to `9.2.1` (the JDK-17-compatible version; also what the JDK-17 `test_app` publish step uses)
- `.github/workflows/build.yml` — the `build` matrix sets `agp` per leg (`17 → 9.2.1`, `21 → 9.3.0`) and exports `ORG_GRADLE_PROJECT_agpVersion`, overriding the default only on the JDK 21 leg

Net effect: **JDK 17 builds/lints/tests on AGP 9.2.1; JDK 21 exercises AGP 9.3.0.** No JDK coverage is dropped.

## Test plan

- [ ] `Build (JDK 17)` green on AGP 9.2.1
- [ ] `Build (JDK 21)` green on AGP 9.3.0 (lint included)
- [ ] `Test App` green (JDK 17, default AGP 9.2.1)

Closes #438.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxmJDWq6wgCEimH3tGLF5H)_