### PR TITLE
ci: fix CodeQL Java extraction and dedupe Dependabot gradle scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,12 @@
 version: 2
 updates:
+  # A single scan at the repo root resolves the whole multi-project Gradle
+  # build (root build.gradle plus the logback-android module), so it covers
+  # dependencies in logback-android/build.gradle too. Listing /logback-android
+  # separately made Dependabot scan that module file twice and open duplicate
+  # PRs for the same bump (e.g. greenmail #441 vs #442).
   - package-ecosystem: "gradle"
-    directories:
-      - "/"
-      - "/logback-android"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 100

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,14 @@ jobs:
 
       # Compile the library so CodeQL can observe the bytecode. The Android SDK
       # is preinstalled on the ubuntu-latest runner (same as the build job).
+      #
+      # --no-daemon keeps javac in a process tree CodeQL's tracer can follow,
+      # and --no-build-cache forces the compile tasks to actually run instead
+      # of resolving FROM-CACHE (the project enables org.gradle.caching). Both
+      # are needed or CodeQL extracts nothing and fails with "no source code
+      # seen during build".
       - name: Assemble
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --no-daemon --no-build-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Two independent CI fixes surfaced while merging the recent Dependabot PRs.

## 1. CodeQL `Analyze (Java)` — "no source code seen during build"

The code-scanning job (added in #436) has failed on every run — on `main` and on every PR — with:

```
CodeQL could not process any code written in Java/Kotlin.
... no-source-code-seen-during-build
CodeQL job status was configuration error.
```

**Cause.** The workflow uses `build-mode: manual` and runs `./gradlew assembleRelease` for CodeQL to trace the compiler. Two things prevented the compile from being observed:
- the **Gradle daemon** ran `javac` in a detached process CodeQL's tracer couldn't follow, and
- the restored **Gradle build cache** (`org.gradle.caching=true`, populated by `gradle/actions/setup-gradle`) served the compile tasks `FROM-CACHE`, so `javac` never actually ran.

Either way CodeQL extracts nothing.

**Fix.** Run the assemble as `./gradlew assembleRelease --no-daemon --no-build-cache` so compilation actually executes and stays in a process tree the tracer can follow.

## 2. Duplicate Dependabot gradle PRs

`dependabot.yml` scanned the `gradle` ecosystem in **two** directories, `/` and `/logback-android`. The root scan already resolves the whole multi-project Gradle build (root `build.gradle` **and** `logback-android/build.gradle`), so the second entry just re-scanned the module file and opened duplicate PRs for the same bump — e.g. greenmail #441 (from `/`) vs #442 (from `/logback-android`).

**Fix.** Collapse to a single `directory: "/"`. Root-level deps (AGP, test-retry) and module deps (greenmail, mockito, …) are all still covered; the duplicates stop.

## Test plan

- [ ] `Analyze (Java)` (CodeQL) passes on this PR — the real validation of fix #1
- [ ] `Build (JDK 17)` / `Build (JDK 21)` / `Test App` remain green
- [ ] Dependabot config change is inert until the next scan (no immediate CI signal)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KxmJDWq6wgCEimH3tGLF5H)_